### PR TITLE
Roxygen documentation improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,3 +42,4 @@ URL: https://rstudio-education.github.io/gradethis/,
     https://github.com/rstudio-education/gradethis
 BugReports: 
     https://github.com/rstudio-education/gradethis/issues
+Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,15 +2,28 @@ Package: gradethis
 Type: Package
 Title: Tools for "grading" student exercises in learnr tutorials
 Version: 0.1.0.9002
-Authors@R: c(
-  person("Daniel", "Chen", role = c("aut"), email = "daniel.chen@rstudio.com"),
-  person("Barret", "Schloerke", role = c("aut"), email = "barret@rstudio.com"),
-  person("Garrett", "Grolemund", role = c("ccp", "aut", "cre"), email = "garrett@rstudio.com"),
-  person(family = "RStudio, Inc.", role = c("cph", "fnd")),
-  person(family = "Ajax.org B.V.", role=c("ctb", "cph"), comment= "Ace library")
-  )
-Description:
-  Pairing with the 'learnr' R package, 'gradethis' provides multiple methods to grade 'learnr' exercises.  To learn more about 'learnr' tutorials, please visit <http://rstudio.github.io/learnr/>.
+Authors@R: 
+    c(person(given = "Daniel",
+             family = "Chen",
+             role = "aut",
+             email = "daniel.chen@rstudio.com"),
+      person(given = "Barret",
+             family = "Schloerke",
+             role = "aut",
+             email = "barret@rstudio.com"),
+      person(given = "Garrett",
+             family = "Grolemund",
+             role = c("ccp", "aut", "cre"),
+             email = "garrett@rstudio.com"),
+      person(family = "RStudio, Inc.",
+             role = c("cph", "fnd")),
+      person(family = "Ajax.org B.V.",
+             role = c("ctb", "cph"),
+             comment = "Ace library"))
+Description: Pairing with the 'learnr' R package,
+    'gradethis' provides multiple methods to grade 'learnr' exercises.  To
+    learn more about 'learnr' tutorials, please visit
+    <http://rstudio.github.io/learnr/>.
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
@@ -23,6 +36,9 @@ Imports:
     checkmate,
     testthat
 Remotes:
-  rstudio/learnr
-URL: https://rstudio-education.github.io/gradethis/, https://rstudio.github.io/learnr/, https://github.com/rstudio-education/gradethis
-BugReports: https://github.com/rstudio-education/gradethis/issues
+    rstudio/learnr
+URL: https://rstudio-education.github.io/gradethis/,
+    https://rstudio.github.io/learnr/,
+    https://github.com/rstudio-education/gradethis
+BugReports: 
+    https://github.com/rstudio-education/gradethis/issues

--- a/R/check_code.R
+++ b/R/check_code.R
@@ -29,12 +29,25 @@
 #'
 #' For best results, name all arguments provided in the solution code.
 #'
-#' @template correct
-#' @template incorrect
-#' @template grader_args
-#' @template learnr_args
-#' @template glue_correct
-#' @template glue_incorrect
+#' @param correct A character string to display if the student answer matches a known correct answer.
+#' 
+#' @param incorrect A character string to display if the student answer matches a known incorrect answer.
+#' 
+#' @param grader_args A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
+#'   This contains: \describe{
+#'    \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
+#'    \item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+#'   }
+#'   
+#' @param learnr_args A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
+#'    See \url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for more details.
+#'    
+#' @param glue_correct A glue string that returns the final correct message displayed.
+#'    Defaults to \code{getOption("gradethis_glue_correct")}.
+#'    
+#' @param glue_incorrect A glue string that returns the final incorrect message displayed.
+#'    Defaults to \code{getOption("gradethis_glue_incorrect")}.
+#'    
 #' @param glue_pipe A glue string that returns the final message displayed when
 #'   the student uses a pipe, `$>$`. Defaults to
 #'   `getOption("gradethis_glue_pipe")`.

--- a/R/check_code.R
+++ b/R/check_code.R
@@ -2,30 +2,30 @@
 #'
 #' Checks the code expression or the code result against a solution.
 #'
-#' \code{check_code()} compares student code to a solution (i.e. model code) and
+#' `check_code()` compares student code to a solution (i.e. model code) and
 #' describes the first way that the student code differs. If the student code
-#' exactly matches the solution, \code{check_code()} returns a customizable
-#' success message (\code{correct}). If the student code does not match the
-#' solution, a customizable incorrect message (\code{incorrect}) can also be
+#' exactly matches the solution, `check_code()` returns a customizable
+#' success message (`correct`). If the student code does not match the
+#' solution, a customizable incorrect message (`incorrect`) can also be
 #' provided.
 #'
-#' \code{check_code()} provides a *strict* check in that the student code must
+#' `check_code()` provides a *strict* check in that the student code must
 #' exactly match the solution. It is not enough for the student code to be
 #' equivalent to the solution code (e.g. to return the same result as the
 #' solution).
 #'
-#' You can provide solution code for \code{check_code()} to use in two ways:
+#' You can provide solution code for `check_code()` to use in two ways:
 #'
 #' 1. Pass code as a character string or a quoted expression to the solution
-#' argument of \code{check_code()}
+#' argument of `check_code()`
 #'
 #' 2. Make a "-solution" code chunk for the exercise to be checked in a learnr
 #' document. There is no need to supply a solution argument for
-#' \code{check_code()} if you call it from the "-check" chunk of the same
+#' `check_code()` if you call it from the "-check" chunk of the same
 #' exercise. Likewise, there is no need to supply a student submitted code
-#' argument when you call \code{check_code()} from a learnr document (learnr
+#' argument when you call `check_code()` from a learnr document (learnr
 #' will provide the code that the student submits when it runs
-#' \code{check_code()}.
+#' `check_code()`.
 #'
 #' For best results, name all arguments provided in the solution code.
 #'
@@ -36,15 +36,15 @@
 #' @template glue_correct
 #' @template glue_incorrect
 #' @param glue_pipe A glue string that returns the final message displayed when
-#'   the student uses a pipe, \code{$>$}. Defaults to
-#'   \code{getOption("gradethis_glue_pipe")}.
+#'   the student uses a pipe, `$>$`. Defaults to
+#'   `getOption("gradethis_glue_pipe")`.
 #'
-#' @return a \code{\link{graded}} object. An incorrect message will describe the
+#' @return a [graded()] object. An incorrect message will describe the
 #'   first way that the answer differs, the message will be the content of the
-#'   \code{glue_pipe} argument.
+#'   `glue_pipe` argument.
 #'
-#' @seealso \code{\link{check_code}}, \code{\link{check_result}}, and
-#'   \code{\link{test_result}}
+#' @seealso [check_code()], [check_result()], and
+#'   [test_result()]
 #' @export
 #' @examples
 #' \dontrun{grading_demo()}

--- a/R/check_code.R
+++ b/R/check_code.R
@@ -1,13 +1,12 @@
-#' Check code against a solution
+#' Check code against a solution.
 #'
 #' Checks the code expression or the code result against a solution.
 #'
 #' `check_code()` compares student code to a solution (i.e. model code) and
 #' describes the first way that the student code differs. If the student code
-#' exactly matches the solution, `check_code()` returns a customizable
-#' success message (`correct`). If the student code does not match the
-#' solution, a customizable incorrect message (`incorrect`) can also be
-#' provided.
+#' exactly matches the solution, `check_code()` returns a customizable success
+#' message (`correct`). If the student code does not match the solution, a
+#' customizable incorrect message (`incorrect`) can also be provided.
 #'
 #' `check_code()` provides a *strict* check in that the student code must
 #' exactly match the solution. It is not enough for the student code to be
@@ -20,49 +19,54 @@
 #' argument of `check_code()`
 #'
 #' 2. Make a "-solution" code chunk for the exercise to be checked in a learnr
-#' document. There is no need to supply a solution argument for
-#' `check_code()` if you call it from the "-check" chunk of the same
-#' exercise. Likewise, there is no need to supply a student submitted code
-#' argument when you call `check_code()` from a learnr document (learnr
-#' will provide the code that the student submits when it runs
-#' `check_code()`.
+#' document. There is no need to supply a solution argument for `check_code()`
+#' if you call it from the "-check" chunk of the same exercise. Likewise, there
+#' is no need to supply a student submitted code argument when you call
+#' `check_code()` from a learnr document (learnr will provide the code that the
+#' student submits when it runs `check_code()`.
 #'
 #' For best results, name all arguments provided in the solution code.
 #'
-#' @param correct A character string to display if the student answer matches a known correct answer.
-#' 
-#' @param incorrect A character string to display if the student answer matches a known incorrect answer.
-#' 
-#' @param grader_args A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
-#'   This contains: \describe{
-#'    \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-#'    \item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
-#'   }
-#'   
-#' @param learnr_args A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
-#'    See \url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for more details.
-#'    
-#' @param glue_correct A glue string that returns the final correct message displayed.
-#'    Defaults to \code{getOption("gradethis_glue_correct")}.
-#'    
-#' @param glue_incorrect A glue string that returns the final incorrect message displayed.
-#'    Defaults to \code{getOption("gradethis_glue_incorrect")}.
-#'    
+#' @param correct A character string to display if the student answer matches a
+#'   known correct answer.
+#'
+#' @param incorrect A character string to display if the student answer matches
+#'   a known incorrect answer.
+#'
+#' @param grader_args A list of parameters passed to `grader` functions
+#'   (provided by [grade_learnr()]). This contains:
+#'
+#'   * `user_quo`: Quoted R code submitted by the user. For example
+#'   `[rlang::quo](1)`
+#'
+#'   * `solution_quo`: (Optional) Quoted solution R code provided by the
+#'   `*-solution` chunk for an exercise.
+#'
+#' @param learnr_args A list of all parameters passed to [grade_learnr()] by
+#'   `learnr`. See
+#'   <https://rstudio.github.io/learnr/exercises.html#exercise_checking> for
+#'   more details.
+#'
+#' @param glue_correct A glue string that returns the final correct message
+#'   displayed. Defaults to `getOption("gradethis_glue_correct")`.
+#'
+#' @param glue_incorrect A glue string that returns the final incorrect message
+#'   displayed. Defaults to `getOption("gradethis_glue_incorrect")`.
+#'
 #' @param glue_pipe A glue string that returns the final message displayed when
 #'   the student uses a pipe, `$>$`. Defaults to
 #'   `getOption("gradethis_glue_pipe")`.
 #'
-#' @return a [graded()] object. An incorrect message will describe the
-#'   first way that the answer differs, the message will be the content of the
-#'   `glue_pipe` argument.
+#' @return a [graded()] object. An incorrect message will describe the first way
+#'   that the answer differs, the message will be the content of the `glue_pipe`
+#'   argument.
 #'
-#' @seealso [check_code()], [check_result()], and
-#'   [test_result()]
+#' @seealso [check_code()], [check_result()], and [test_result()]
 #' @export
 #' @examples
 #' \dontrun{grading_demo()}
 #'
-#' # This is a manual example, see grading demo for learnr tutorial usage
+#' # This is a manual example, see grading demo for `learnr` tutorial usage
 #' y <- quote(sqrt(log(2)))
 #' z <- quote(sqrt(log(1)))
 #' check_code(grader_args = list(user_quo = y, solution_quo = z))

--- a/R/check_result.R
+++ b/R/check_result.R
@@ -1,12 +1,12 @@
 
 #' Check result of exercise code
 #'
-#' \code{check_result()} compares the final result of the student code to known
-#' \code{\link{pass_if}} and \code{\link{fail_if}} \code{\link{condition}}s.
-#' If the student result exactly matches a known case, \code{check_result}
+#' `check_result()` compares the final result of the student code to known
+#' [pass_if()] and [fail_if()] [condition()]s.
+#' If the student result exactly matches a known case, `check_result`
 #' returns the matching message value.
 #'
-#' @param ... \code{\link{pass_if}} or \code{\link{fail_if}} \code{\link{condition}}s to check
+#' @param ... [pass_if()] or [fail_if()] [condition()]s to check
 #' @template correct
 #' @template incorrect
 #' @template grader_args
@@ -14,11 +14,11 @@
 #' @template glue_correct
 #' @template glue_incorrect
 #'
-#' @return a \code{\link{graded}} object from either
-#'   \code{\link{pass_if}} or \code{\link{fail_if}} containing a formatted
-#'   \code{correct} or \code{incorrect} message and whether or not a match was found.
+#' @return a [graded()] object from either
+#'   [pass_if()] or [fail_if()] containing a formatted
+#'   `correct` or `incorrect` message and whether or not a match was found.
 #'
-#' @seealso \code{\link{check_code}}, \code{\link{check_result}}, and \code{\link{test_result}}
+#' @seealso [check_code()], [check_result()], and [test_result()]
 #' @export
 #' @examples
 #' \dontrun{grading_demo()}

--- a/R/check_result.R
+++ b/R/check_result.R
@@ -1,18 +1,16 @@
-
-#' Check result of exercise code
+#' Check result of exercise code.
 #'
-#' `check_result()` compares the final result of the student code to known
-#' [pass_if()] and [fail_if()] [condition()]s.
-#' If the student result exactly matches a known case, `check_result`
-#' returns the matching message value.
+#' Compares the final result of the student code to known [pass_if()] and
+#' [fail_if()] [condition()]s. If the student result exactly matches a known
+#' case, returns the matching message value.
 #'
 #' @inheritParams check_code
-#' 
+#'
 #' @param ... [pass_if()] or [fail_if()] [condition()]s to check
 #'
-#' @return a [graded()] object from either
-#'   [pass_if()] or [fail_if()] containing a formatted
-#'   `correct` or `incorrect` message and whether or not a match was found.
+#' @return a [graded()] object from either [pass_if()] or [fail_if()] containing
+#'   a formatted `correct` or `incorrect` message and whether or not a match was
+#'   found.
 #'
 #' @seealso [check_code()], [check_result()], and [test_result()]
 #' @export

--- a/R/check_result.R
+++ b/R/check_result.R
@@ -6,13 +6,9 @@
 #' If the student result exactly matches a known case, `check_result`
 #' returns the matching message value.
 #'
+#' @inheritParams check_code
+#' 
 #' @param ... [pass_if()] or [fail_if()] [condition()]s to check
-#' @template correct
-#' @template incorrect
-#' @template grader_args
-#' @template learnr_args
-#' @template glue_correct
-#' @template glue_incorrect
 #'
 #' @return a [graded()] object from either
 #'   [pass_if()] or [fail_if()] containing a formatted

--- a/R/condition.R
+++ b/R/condition.R
@@ -1,18 +1,19 @@
-#' Condition object
+#' Condition object.
 #'
 #' Captures what the student passes into [pass_if()] or [fail_if()],
 #' figures out what type of object was passed into `x`,
 #' and returns a `grader_condition` object that will be passed into
 #' [evaluate_condition()].
 #'
-#' @param x A formula, function, or value, that returns \code{TRUE} or \code{FALSE}.
+#' @param x A formula, function, or value, that returns `TRUE` or `FALSE`.
 #'    When comparing objects that are greater than length 1 (e.g., vectors, dataframes, matricies, etc)
-#'    A boolean vector will be returned if the user uses \code{==}, not a single boolean value.
-#'    \code{gradethis} will run the vector through \code{all(..., na.rm = TRUE)} to check for the boolean value.
-#'    It is advised that the user use \code{identical()} instead of \code{==} in this case.
+#'    A boolean vector will be returned if the user uses `==`, not a single boolean value.
+#'    `gradethis` will run the vector through `all(..., na.rm = TRUE)` to check for the boolean value.
+#'    It is advised that the user use `identical()` instead of `==` in this case.
 
 #' @param message character string for message returned (usually passed in from
 #'    [pass_if()] or [fail_if()]
+#'    
 #' @param correct logical whether the condition is the correct answer
 #'
 #' @return a `grader_condition` object that contains

--- a/R/condition.R
+++ b/R/condition.R
@@ -5,7 +5,12 @@
 #' and returns a `grader_condition` object that will be passed into
 #' [evaluate_condition()].
 #'
-#' @template x_condition
+#' @param x A formula, function, or value, that returns \code{TRUE} or \code{FALSE}.
+#'    When comparing objects that are greater than length 1 (e.g., vectors, dataframes, matricies, etc)
+#'    A boolean vector will be returned if the user uses \code{==}, not a single boolean value.
+#'    \code{gradethis} will run the vector through \code{all(..., na.rm = TRUE)} to check for the boolean value.
+#'    It is advised that the user use \code{identical()} instead of \code{==} in this case.
+
 #' @param message character string for message returned (usually passed in from
 #'    [pass_if()] or [fail_if()]
 #' @param correct logical whether the condition is the correct answer

--- a/R/condition.R
+++ b/R/condition.R
@@ -1,25 +1,25 @@
 #' Condition object
 #'
-#' Captures what the student passes into \code{\link{pass_if}} or \code{\link{fail_if}},
-#' figures out what type of object was passed into \code{x},
-#' and returns a \code{grader_condition} object that will be passed into
-#' \code{\link{evaluate_condition}}.
+#' Captures what the student passes into [pass_if()] or [fail_if()],
+#' figures out what type of object was passed into `x`,
+#' and returns a `grader_condition` object that will be passed into
+#' [evaluate_condition()].
 #'
 #' @template x_condition
 #' @param message character string for message returned (usually passed in from
-#'    \code{\link{pass_if}} or \code{\link{fail_if}}
+#'    [pass_if()] or [fail_if()]
 #' @param correct logical whether the condition is the correct answer
 #'
-#' @return a \code{grader_condition} object that contains
-#'   the expression \code{x},
-#'   the message \code{message},
-#'   whether or not the expression is the correct answer or not, \code{correct},
-#'   the type of expression (formula, function, or value), \code{type}
+#' @return a `grader_condition` object that contains
+#'   the expression `x`,
+#'   the message `message`,
+#'   whether or not the expression is the correct answer or not, `correct`,
+#'   the type of expression (formula, function, or value), `type`
 #'
 #' @describeIn condition
 #'    A condition object that contains the expression, message,
 #'    correct status, and condition type
-#' @seealso \code{\link{pass_if}}, \code{\link{fail_if}}, and \code{\link{condition}}
+#' @seealso [pass_if()], [fail_if()], and [condition()]
 #' @export
 #'
 #' @examples

--- a/R/evaluate_condition.R
+++ b/R/evaluate_condition.R
@@ -1,13 +1,13 @@
 #' Evaluates a condition
 #'
-#' Evaluates the \code{\link{condition}} object to return a \code{\link{graded}} value.
+#' Evaluates the [condition()] object to return a [graded()] value.
 #'
-#' @param condition a \code{\link{condition}} object
-#' @param grader_args at minimum, a list that just contains the value for \code{solution_quo}
-#' @param learnr_args at minimum, a list that just contains the value for \code{envir_prep}
+#' @param condition a [condition()] object
+#' @param grader_args at minimum, a list that just contains the value for `solution_quo`
+#' @param learnr_args at minimum, a list that just contains the value for `envir_prep`
 #'
-#' @return a \code{\link{graded}} value if \code{condi$x} is \code{TRUE} or
-#'   \code{NULL} if \code{condi$x} is \code{FALSE}
+#' @return a [graded()] value if `condi$x` is `TRUE` or
+#'   `NULL` if `condi$x` is `FALSE`
 #' @export
 #'
 #' @examples

--- a/R/get_code.R
+++ b/R/get_code.R
@@ -1,11 +1,11 @@
 #' Get Code
 #'
-#' Helper methods around \code{rlang::\link[rlang]{eval_tidy}}
+#' Helper methods around `rlang::[eval_tidy][rlang::eval_tidy]`
 #' to extract user code and solution code.
 #'
-#' @seealso \code{\link{check_result}}, \code{\link{test_result}}, and \code{\link{check_code}}
+#' @seealso [check_result()], [test_result()], and [check_code()]
 #' @param user,solution,expr An expression or quosure to evaluate.
-#' @param name Name to print if a \code{NULL} expression is provided.
+#' @param name Name to print if a `NULL` expression is provided.
 #'
 #' @describeIn get_code Get student code
 #' @inheritParams rlang::eval_tidy

--- a/R/glue.R
+++ b/R/glue.R
@@ -1,6 +1,6 @@
 #' Generate Glue string from expression
 #'
-#' Checks and validates arguments passed into \code{glue} to generate messages to the student.
+#' Checks and validates arguments passed into `glue` to generate messages to the student.
 #'
 #' @param glue_expression A glue character expression string.
 #' @param ... Values to be inserted into glue expression.

--- a/R/grade_learnr.R
+++ b/R/grade_learnr.R
@@ -1,20 +1,20 @@
-#' A checker function to use with \code{learnr}
+#' A checker function to use with `learnr`
 #'
-#' For exercise checking, \code{learnr} tutorials require a function that
-#' \code{learnr} can use in the background to run the code in each "-check"
-#' chunk and to format the results into a format that \code{learnr} can display.
+#' For exercise checking, `learnr` tutorials require a function that
+#' `learnr` can use in the background to run the code in each "-check"
+#' chunk and to format the results into a format that `learnr` can display.
 #' The function must accept a specific set of inputs and return a specific type
-#' of output (see \code{\link{graded}}). Instructors are not intended to use the
-#' \code{grade_learnr} function directly, but to pass it to the
-#' \code{exercise.checker} knitr chunk option within the setup chunk of the
-#' \code{learnr} tutorial.
+#' of output (see [graded()]). Instructors are not intended to use the
+#' `grade_learnr` function directly, but to pass it to the
+#' `exercise.checker` knitr chunk option within the setup chunk of the
+#' `learnr` tutorial.
 #'
 #' To enable exercise checking in your learnr tutorial, set
-#' \code{tutorial_options(exercise.checker = grade_learnr)} in the setup chunk
+#' `tutorial_options(exercise.checker = grade_learnr)` in the setup chunk
 #' of your tutorial.
 #'
-#' Run \code{grading_demo()} to see an example learnr document that uses
-#' \code{grade_learnr()}.
+#' Run `grading_demo()` to see an example learnr document that uses
+#' `grade_learnr()`.
 #'
 #' @param label Label for exercise chunk
 #' @param solution_code Code provided within the “-solution” chunk for the
@@ -22,7 +22,7 @@
 #' @param user_code R code submitted by the user
 #' @param check_code Code provided within the “-check” chunk for the exercise.
 #' @param envir_result The R environment after the execution of the chunk.
-#' @param evaluate_result The return value from the \code{evaluate::evaluate}
+#' @param evaluate_result The return value from the `evaluate::evaluate`
 #'   function.
 #' @param envir_prep A copy of the R environment before the execution of the
 #'   chunk.

--- a/R/graded.R
+++ b/R/graded.R
@@ -1,7 +1,7 @@
 #' Graded submission value
 #'
-#'The return value from \code{graded} should be returned by every
-#'\code{*-check} chunk when used with \code{link{grade_learnr}}.
+#'The return value from `graded` should be returned by every
+#'`*-check` chunk when used with \code{link{grade_learnr}}.
 #'
 #' @param message A character string of the message to be displayed.
 #' @param correct A boolean value of whether or not the checked code is correct.

--- a/R/grading_demo.R
+++ b/R/grading_demo.R
@@ -1,20 +1,23 @@
 #' Grading Demo
 #'
-#' If you are using the RStudio IDE, \code{grading_demo()} opens an example learnr
+#' If you are using the RStudio IDE, `grading_demo()` opens an example learnr
 #' file that demonstrates how to use the grader package to check student code.
 #'
-#' The tutorial sets the learnr \code{exercise.checker} option to
-#' \code{grade_learnr()} in the document's setup chunk.
+#' The tutorial sets the learnr `exercise.checker` option to
+#' `grade_learnr()` in the document's setup chunk.
+#' 
 #' It then uses three different exercise checking methods:
-#' \code{\link{check_result}}, \code{\link{test_result}}, and \code{\link{check_code}}.
+#' [check_result()], [test_result()], and [check_code()].
+#' 
 #' To use a checking method, follow the exercise chunk with a chunk whose label
-#' matches the label of the exercise chunk (ex: \code{myexercise}) but includes the suffix
-#' \code{-check} (ex: \code{myexercise-check}). Call any checking method in that chunk.
+#' matches the label of the exercise chunk (ex: `myexercise`) but includes the suffix
+#' `-check` (ex: `myexercise-check`). Call any checking method in that chunk.
+#' 
 #' To ensure that checking method can provide informative feedback,
-#' you may provide custom \code{correct} and \code{incorrect} messages.
+#' you may provide custom `correct` and `incorrect` messages.
 #'
 #' If you are not using RStudio IDE, you can access the demo file at
-#' \code{system.file("extdata", "grading-demo/grading-demo.Rmd", package = "grader")}.
+#' `system.file("extdata", "grading-demo/grading-demo.Rmd", package = "grader")`.
 #'
 #' @export
 #' @importFrom utils browseURL

--- a/R/order_calls.R
+++ b/R/order_calls.R
@@ -1,7 +1,7 @@
 #' Order calls
 #'
 #' Turns a quoted object into a list of symbols that would represent the call as
-#' a pipe if you placed a \code{\%>\%} between each element of the list. This
+#' a pipe if you placed a `\%>\%` between each element of the list. This
 #' let's checking code evaluate the elements in the same order that R would.
 #'
 #' @noRd

--- a/R/pass_fail_if.R
+++ b/R/pass_fail_if.R
@@ -1,9 +1,9 @@
 #' Condition definition
 #'
-#' \code{pass_if} and \code{fail_if} are wrappers around \code{\link{condition}}
-#' that sets the proper \code{correct} argument.
-#' This allows the instructor to specify just the comparison code, \code{x},
-#' and \code{message}.
+#' `pass_if` and `fail_if` are wrappers around [condition()]
+#' that sets the proper `correct` argument.
+#' This allows the instructor to specify just the comparison code, `x`,
+#' and `message`.
 #'
 #' @describeIn condition
 #'    a condition that if matched means the student provided result is correct

--- a/R/praise.R
+++ b/R/praise.R
@@ -58,7 +58,7 @@
 #'
 #' Generate a random praise or encouragement phrase.
 #' This can be used in conjunction with
-#' \code{glue::\link[glue]{glue}} to generate praise or encouragement within feedback to users.
+#' `glue::[glue][glue::glue]` to generate praise or encouragement within feedback to users.
 #'
 #' @examples
 #' replicate(5, glue::glue("Random praise: {random_praise()}"))

--- a/R/test_result.R
+++ b/R/test_result.R
@@ -2,6 +2,8 @@
 #'
 #' `test_result()` executes tests against the final result of the user code.
 #' If a test throws an error, the test fails and the submitted answer will be marked incorrect.
+#' 
+#' @inheritParams check_code
 #'
 #' @param correct A character string to display if all tests pass.
 #'   This character string will be run through `glue::[glue_data][glue::glue_data]` with
@@ -17,9 +19,8 @@
 #'   \item `num_total`: Number of tests
 #'   \item `errors`: Vector of errors found
 #' }
-#' @template grader_args
-#' @template learnr_args
 #' @param ... ignored
+#' 
 #'
 #' @return a `grader_graded` structure from [graded()] containing
 #'   a formatted `correct` or `incorrect` message.

--- a/R/test_result.R
+++ b/R/test_result.R
@@ -1,29 +1,29 @@
 #' Test the result of exercise code
 #'
-#' \code{test_result()} executes tests against the final result of the user code.
+#' `test_result()` executes tests against the final result of the user code.
 #' If a test throws an error, the test fails and the submitted answer will be marked incorrect.
 #'
 #' @param correct A character string to display if all tests pass.
-#'   This character string will be run through \code{glue::\link[glue]{glue_data}} with
+#'   This character string will be run through `glue::[glue_data][glue::glue_data]` with
 #' \itemize{
-#'   \item \code{num_correct}: Number of correct tests. (Equals \code{num_total})
-#'   \item \code{num_total}: Number of tests
-#'   \item \code{errors}: Vector of errors found. (\code{NULL})
+#'   \item `num_correct`: Number of correct tests. (Equals `num_total`)
+#'   \item `num_total`: Number of tests
+#'   \item `errors`: Vector of errors found. (`NULL`)
 #' }
 #' @param incorrect A character string to display if at least one test fails.
-#'   This character string will be run through \code{glue::\link[glue]{glue_data}} with
+#'   This character string will be run through `glue::[glue_data][glue::glue_data]` with
 #' \itemize{
-#'   \item \code{num_correct}: Number of correct tests
-#'   \item \code{num_total}: Number of tests
-#'   \item \code{errors}: Vector of errors found
+#'   \item `num_correct`: Number of correct tests
+#'   \item `num_total`: Number of tests
+#'   \item `errors`: Vector of errors found
 #' }
 #' @template grader_args
 #' @template learnr_args
 #' @param ... ignored
 #'
-#' @return a \code{grader_graded} structure from \code{\link{graded}} containing
-#'   a formatted \code{correct} or \code{incorrect} message.
-#' @seealso \code{test}
+#' @return a `grader_graded` structure from [graded()] containing
+#'   a formatted `correct` or `incorrect` message.
+#' @seealso `test`
 #' @export
 #' @examples
 #' \dontrun{grading_demo()}

--- a/R/test_result.R
+++ b/R/test_result.R
@@ -1,29 +1,34 @@
-#' Test the result of exercise code
+#' Test the result of exercise code.
 #'
-#' `test_result()` executes tests against the final result of the user code.
-#' If a test throws an error, the test fails and the submitted answer will be marked incorrect.
-#' 
+#' Executes tests against the final result of the user code. If
+#' a test throws an error, the test fails and the submitted answer will be
+#' marked incorrect.
+#'
 #' @inheritParams check_code
 #'
-#' @param correct A character string to display if all tests pass.
-#'   This character string will be run through `glue::[glue_data][glue::glue_data]` with
-#' \itemize{
-#'   \item `num_correct`: Number of correct tests. (Equals `num_total`)
-#'   \item `num_total`: Number of tests
-#'   \item `errors`: Vector of errors found. (`NULL`)
-#' }
-#' @param incorrect A character string to display if at least one test fails.
-#'   This character string will be run through `glue::[glue_data][glue::glue_data]` with
-#' \itemize{
-#'   \item `num_correct`: Number of correct tests
-#'   \item `num_total`: Number of tests
-#'   \item `errors`: Vector of errors found
-#' }
-#' @param ... ignored
-#' 
+#' @param correct A character string to display if all tests pass. This
+#'   character string will be run through `[glue::glue_data]` with:
 #'
-#' @return a `grader_graded` structure from [graded()] containing
-#'   a formatted `correct` or `incorrect` message.
+#'   * `num_correct`: Number of correct tests. (Equals `num_total`)
+#'
+#'   * `num_total`: Number of tests
+#'
+#'   * `errors`: Vector of errors found. (`NULL`)
+#'
+#' @param incorrect A character string to display if at least one test fails.
+#'   This character string will be run through `][glue::glue_data]` with:
+#'
+#'   * `num_correct`: Number of correct tests
+#'
+#'   * `num_total`: Number of tests
+#'
+#'   * `errors`: Vector of errors found
+#'
+#' @param ... ignored
+#'
+#'
+#' @return a `grader_graded` structure from [graded()] containing a formatted
+#'   `correct` or `incorrect` message.
 #' @seealso `test`
 #' @export
 #' @examples

--- a/R/unpipe.R
+++ b/R/unpipe.R
@@ -2,9 +2,9 @@
 #'
 #' Unpipe one layer of piped code.
 #'
-#' \code{unpipe()} removes one call to \%>\% from an expression,
+#' `unpipe()` removes one call to \%>\% from an expression,
 #' reformatting the result as a nested function call. If the code does not
-#' contain a top-level call to \%>\%, \code{unpipe()} returns it as is.
+#' contain a top-level call to \%>\%, `unpipe()` returns it as is.
 #'
 #' @param code a quoted piece of code
 unpipe <- function(code) {

--- a/man-roxygen/correct.R
+++ b/man-roxygen/correct.R
@@ -1,1 +1,0 @@
-#' @param correct A character string to display if the student answer matches a known correct answer.

--- a/man-roxygen/glue_correct.R
+++ b/man-roxygen/glue_correct.R
@@ -1,2 +1,0 @@
-#' @param glue_correct A glue string that returns the final correct message displayed.
-#'    Defaults to \code{getOption("gradethis_glue_correct")}.

--- a/man-roxygen/grader_args.R
+++ b/man-roxygen/grader_args.R
@@ -1,5 +1,0 @@
-#' @param grader_args A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
-#'   This contains: \describe{
-#'    \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-#'    \item{\code{solution_quo}}{[Optional] Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
-#'   }

--- a/man-roxygen/incorrect.R
+++ b/man-roxygen/incorrect.R
@@ -1,1 +1,0 @@
-#' @param incorrect A character string to display if the student answer matches a known incorrect answer.

--- a/man-roxygen/learnr_args.R
+++ b/man-roxygen/learnr_args.R
@@ -1,2 +1,0 @@
-#' @param learnr_args A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
-#'    See \url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for more details.

--- a/man-roxygen/x_condition.R
+++ b/man-roxygen/x_condition.R
@@ -1,5 +1,0 @@
-#' @param x A formula, function, or value, that returns \code{TRUE} or \code{FALSE}.
-#'    When comparing objects that are greater than length 1 (e.g., vectors, dataframes, matricies, etc)
-#'    A boolean vector will be returned if the user uses \code{==}, not a single boolean value.
-#'    \code{gradethis} will run the vector through \code{all(..., na.rm = TRUE)} to check for the boolean value.
-#'    It is advised that the user use \code{identical()} instead of \code{==} in this case.

--- a/man/check_code.Rd
+++ b/man/check_code.Rd
@@ -18,7 +18,7 @@ check_code(correct = NULL, incorrect = NULL, grader_args = list(),
 \item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
 This contains: \describe{
 \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-\item{\code{solution_quo}}{\link{Optional} Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
 }}
 
 \item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.

--- a/man/check_code.Rd
+++ b/man/check_code.Rd
@@ -17,8 +17,8 @@ check_code(correct = NULL, incorrect = NULL, grader_args = list(),
 
 \item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
 This contains: \describe{
- \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
- \item{\code{solution_quo}}{[Optional] Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
+\item{\code{solution_quo}}{\link{Optional} Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
 }}
 
 \item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
@@ -35,9 +35,9 @@ the student uses a pipe, \code{$>$}. Defaults to
 \code{getOption("gradethis_glue_pipe")}.}
 }
 \value{
-a \code{\link{graded}} object. An incorrect message will describe the
-  first way that the answer differs, the message will be the content of the
-  \code{glue_pipe} argument.
+a \code{\link[=graded]{graded()}} object. An incorrect message will describe the
+first way that the answer differs, the message will be the content of the
+\code{glue_pipe} argument.
 }
 \description{
 Checks the code expression or the code result against a solution.
@@ -50,23 +50,23 @@ success message (\code{correct}). If the student code does not match the
 solution, a customizable incorrect message (\code{incorrect}) can also be
 provided.
 
-\code{check_code()} provides a *strict* check in that the student code must
+\code{check_code()} provides a \emph{strict} check in that the student code must
 exactly match the solution. It is not enough for the student code to be
 equivalent to the solution code (e.g. to return the same result as the
 solution).
 
 You can provide solution code for \code{check_code()} to use in two ways:
-
-1. Pass code as a character string or a quoted expression to the solution
+\enumerate{
+\item Pass code as a character string or a quoted expression to the solution
 argument of \code{check_code()}
-
-2. Make a "-solution" code chunk for the exercise to be checked in a learnr
+\item Make a "-solution" code chunk for the exercise to be checked in a learnr
 document. There is no need to supply a solution argument for
 \code{check_code()} if you call it from the "-check" chunk of the same
 exercise. Likewise, there is no need to supply a student submitted code
 argument when you call \code{check_code()} from a learnr document (learnr
 will provide the code that the student submits when it runs
 \code{check_code()}.
+}
 
 For best results, name all arguments provided in the solution code.
 }
@@ -79,6 +79,6 @@ z <- quote(sqrt(log(1)))
 check_code(grader_args = list(user_quo = y, solution_quo = z))
 }
 \seealso{
-\code{\link{check_code}}, \code{\link{check_result}}, and
-  \code{\link{test_result}}
+\code{\link[=check_code]{check_code()}}, \code{\link[=check_result]{check_result()}}, and
+\code{\link[=test_result]{test_result()}}
 }

--- a/man/check_code.Rd
+++ b/man/check_code.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/check_code.R
 \name{check_code}
 \alias{check_code}
-\title{Check code against a solution}
+\title{Check code against a solution.}
 \usage{
 check_code(correct = NULL, incorrect = NULL, grader_args = list(),
   learnr_args = list(),
@@ -11,33 +11,40 @@ check_code(correct = NULL, incorrect = NULL, grader_args = list(),
   glue_pipe = getOption("gradethis_glue_pipe"))
 }
 \arguments{
-\item{correct}{A character string to display if the student answer matches a known correct answer.}
+\item{correct}{A character string to display if the student answer matches a
+known correct answer.}
 
-\item{incorrect}{A character string to display if the student answer matches a known incorrect answer.}
+\item{incorrect}{A character string to display if the student answer matches
+a known incorrect answer.}
 
-\item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
-This contains: \describe{
-\item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-\item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{grader_args}{A list of parameters passed to \code{grader} functions
+(provided by \code{\link[=grade_learnr]{grade_learnr()}}). This contains:
+\itemize{
+\item \code{user_quo}: Quoted R code submitted by the user. For example
+\code{[rlang::quo](1)}
+\item \code{solution_quo}: (Optional) Quoted solution R code provided by the
+\code{*-solution} chunk for an exercise.
 }}
 
-\item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
-See \url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for more details.}
+\item{learnr_args}{A list of all parameters passed to \code{\link[=grade_learnr]{grade_learnr()}} by
+\code{learnr}. See
+\url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for
+more details.}
 
-\item{glue_correct}{A glue string that returns the final correct message displayed.
-Defaults to \code{getOption("gradethis_glue_correct")}.}
+\item{glue_correct}{A glue string that returns the final correct message
+displayed. Defaults to \code{getOption("gradethis_glue_correct")}.}
 
-\item{glue_incorrect}{A glue string that returns the final incorrect message displayed.
-Defaults to \code{getOption("gradethis_glue_incorrect")}.}
+\item{glue_incorrect}{A glue string that returns the final incorrect message
+displayed. Defaults to \code{getOption("gradethis_glue_incorrect")}.}
 
 \item{glue_pipe}{A glue string that returns the final message displayed when
 the student uses a pipe, \code{$>$}. Defaults to
 \code{getOption("gradethis_glue_pipe")}.}
 }
 \value{
-a \code{\link[=graded]{graded()}} object. An incorrect message will describe the
-first way that the answer differs, the message will be the content of the
-\code{glue_pipe} argument.
+a \code{\link[=graded]{graded()}} object. An incorrect message will describe the first way
+that the answer differs, the message will be the content of the \code{glue_pipe}
+argument.
 }
 \description{
 Checks the code expression or the code result against a solution.
@@ -45,10 +52,9 @@ Checks the code expression or the code result against a solution.
 \details{
 \code{check_code()} compares student code to a solution (i.e. model code) and
 describes the first way that the student code differs. If the student code
-exactly matches the solution, \code{check_code()} returns a customizable
-success message (\code{correct}). If the student code does not match the
-solution, a customizable incorrect message (\code{incorrect}) can also be
-provided.
+exactly matches the solution, \code{check_code()} returns a customizable success
+message (\code{correct}). If the student code does not match the solution, a
+customizable incorrect message (\code{incorrect}) can also be provided.
 
 \code{check_code()} provides a \emph{strict} check in that the student code must
 exactly match the solution. It is not enough for the student code to be
@@ -60,12 +66,11 @@ You can provide solution code for \code{check_code()} to use in two ways:
 \item Pass code as a character string or a quoted expression to the solution
 argument of \code{check_code()}
 \item Make a "-solution" code chunk for the exercise to be checked in a learnr
-document. There is no need to supply a solution argument for
-\code{check_code()} if you call it from the "-check" chunk of the same
-exercise. Likewise, there is no need to supply a student submitted code
-argument when you call \code{check_code()} from a learnr document (learnr
-will provide the code that the student submits when it runs
-\code{check_code()}.
+document. There is no need to supply a solution argument for \code{check_code()}
+if you call it from the "-check" chunk of the same exercise. Likewise, there
+is no need to supply a student submitted code argument when you call
+\code{check_code()} from a learnr document (learnr will provide the code that the
+student submits when it runs \code{check_code()}.
 }
 
 For best results, name all arguments provided in the solution code.
@@ -73,12 +78,11 @@ For best results, name all arguments provided in the solution code.
 \examples{
 \dontrun{grading_demo()}
 
-# This is a manual example, see grading demo for learnr tutorial usage
+# This is a manual example, see grading demo for `learnr` tutorial usage
 y <- quote(sqrt(log(2)))
 z <- quote(sqrt(log(1)))
 check_code(grader_args = list(user_quo = y, solution_quo = z))
 }
 \seealso{
-\code{\link[=check_code]{check_code()}}, \code{\link[=check_result]{check_result()}}, and
-\code{\link[=test_result]{test_result()}}
+\code{\link[=check_code]{check_code()}}, \code{\link[=check_result]{check_result()}}, and \code{\link[=test_result]{test_result()}}
 }

--- a/man/check_result.Rd
+++ b/man/check_result.Rd
@@ -10,7 +10,7 @@ check_result(..., correct = NULL, incorrect = NULL,
   glue_incorrect = getOption("gradethis_glue_incorrect"))
 }
 \arguments{
-\item{...}{\code{\link{pass_if}} or \code{\link{fail_if}} \code{\link{condition}}s to check}
+\item{...}{\code{\link[=pass_if]{pass_if()}} or \code{\link[=fail_if]{fail_if()}} \code{\link[=condition]{condition()}}s to check}
 
 \item{correct}{A character string to display if the student answer matches a known correct answer.}
 
@@ -18,8 +18,8 @@ check_result(..., correct = NULL, incorrect = NULL,
 
 \item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
 This contains: \describe{
- \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
- \item{\code{solution_quo}}{[Optional] Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
+\item{\code{solution_quo}}{\link{Optional} Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
 }}
 
 \item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
@@ -32,13 +32,13 @@ Defaults to \code{getOption("gradethis_glue_correct")}.}
 Defaults to \code{getOption("gradethis_glue_incorrect")}.}
 }
 \value{
-a \code{\link{graded}} object from either
-  \code{\link{pass_if}} or \code{\link{fail_if}} containing a formatted
-  \code{correct} or \code{incorrect} message and whether or not a match was found.
+a \code{\link[=graded]{graded()}} object from either
+\code{\link[=pass_if]{pass_if()}} or \code{\link[=fail_if]{fail_if()}} containing a formatted
+\code{correct} or \code{incorrect} message and whether or not a match was found.
 }
 \description{
 \code{check_result()} compares the final result of the student code to known
-\code{\link{pass_if}} and \code{\link{fail_if}} \code{\link{condition}}s.
+\code{\link[=pass_if]{pass_if()}} and \code{\link[=fail_if]{fail_if()}} \code{\link[=condition]{condition()}}s.
 If the student result exactly matches a known case, \code{check_result}
 returns the matching message value.
 }
@@ -68,5 +68,5 @@ check_result(
 )
 }
 \seealso{
-\code{\link{check_code}}, \code{\link{check_result}}, and \code{\link{test_result}}
+\code{\link[=check_code]{check_code()}}, \code{\link[=check_result]{check_result()}}, and \code{\link[=test_result]{test_result()}}
 }

--- a/man/check_result.Rd
+++ b/man/check_result.Rd
@@ -19,7 +19,7 @@ check_result(..., correct = NULL, incorrect = NULL,
 \item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
 This contains: \describe{
 \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-\item{\code{solution_quo}}{\link{Optional} Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
 }}
 
 \item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.

--- a/man/check_result.Rd
+++ b/man/check_result.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/check_result.R
 \name{check_result}
 \alias{check_result}
-\title{Check result of exercise code}
+\title{Check result of exercise code.}
 \usage{
 check_result(..., correct = NULL, incorrect = NULL,
   grader_args = list(), learnr_args = list(),
@@ -12,35 +12,41 @@ check_result(..., correct = NULL, incorrect = NULL,
 \arguments{
 \item{...}{\code{\link[=pass_if]{pass_if()}} or \code{\link[=fail_if]{fail_if()}} \code{\link[=condition]{condition()}}s to check}
 
-\item{correct}{A character string to display if the student answer matches a known correct answer.}
+\item{correct}{A character string to display if the student answer matches a
+known correct answer.}
 
-\item{incorrect}{A character string to display if the student answer matches a known incorrect answer.}
+\item{incorrect}{A character string to display if the student answer matches
+a known incorrect answer.}
 
-\item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
-This contains: \describe{
-\item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-\item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{grader_args}{A list of parameters passed to \code{grader} functions
+(provided by \code{\link[=grade_learnr]{grade_learnr()}}). This contains:
+\itemize{
+\item \code{user_quo}: Quoted R code submitted by the user. For example
+\code{[rlang::quo](1)}
+\item \code{solution_quo}: (Optional) Quoted solution R code provided by the
+\code{*-solution} chunk for an exercise.
 }}
 
-\item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
-See \url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for more details.}
+\item{learnr_args}{A list of all parameters passed to \code{\link[=grade_learnr]{grade_learnr()}} by
+\code{learnr}. See
+\url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for
+more details.}
 
-\item{glue_correct}{A glue string that returns the final correct message displayed.
-Defaults to \code{getOption("gradethis_glue_correct")}.}
+\item{glue_correct}{A glue string that returns the final correct message
+displayed. Defaults to \code{getOption("gradethis_glue_correct")}.}
 
-\item{glue_incorrect}{A glue string that returns the final incorrect message displayed.
-Defaults to \code{getOption("gradethis_glue_incorrect")}.}
+\item{glue_incorrect}{A glue string that returns the final incorrect message
+displayed. Defaults to \code{getOption("gradethis_glue_incorrect")}.}
 }
 \value{
-a \code{\link[=graded]{graded()}} object from either
-\code{\link[=pass_if]{pass_if()}} or \code{\link[=fail_if]{fail_if()}} containing a formatted
-\code{correct} or \code{incorrect} message and whether or not a match was found.
+a \code{\link[=graded]{graded()}} object from either \code{\link[=pass_if]{pass_if()}} or \code{\link[=fail_if]{fail_if()}} containing
+a formatted \code{correct} or \code{incorrect} message and whether or not a match was
+found.
 }
 \description{
-\code{check_result()} compares the final result of the student code to known
-\code{\link[=pass_if]{pass_if()}} and \code{\link[=fail_if]{fail_if()}} \code{\link[=condition]{condition()}}s.
-If the student result exactly matches a known case, \code{check_result}
-returns the matching message value.
+Compares the final result of the student code to known \code{\link[=pass_if]{pass_if()}} and
+\code{\link[=fail_if]{fail_if()}} \code{\link[=condition]{condition()}}s. If the student result exactly matches a known
+case, returns the matching message value.
 }
 \examples{
 \dontrun{grading_demo()}

--- a/man/condition.Rd
+++ b/man/condition.Rd
@@ -20,24 +20,24 @@ A boolean vector will be returned if the user uses \code{==}, not a single boole
 It is advised that the user use \code{identical()} instead of \code{==} in this case.}
 
 \item{message}{character string for message returned (usually passed in from
-\code{\link{pass_if}} or \code{\link{fail_if}}}
+\code{\link[=pass_if]{pass_if()}} or \code{\link[=fail_if]{fail_if()}}}
 
 \item{correct}{logical whether the condition is the correct answer}
 }
 \value{
 a \code{grader_condition} object that contains
-  the expression \code{x},
-  the message \code{message},
-  whether or not the expression is the correct answer or not, \code{correct},
-  the type of expression (formula, function, or value), \code{type}
+the expression \code{x},
+the message \code{message},
+whether or not the expression is the correct answer or not, \code{correct},
+the type of expression (formula, function, or value), \code{type}
 }
 \description{
-Captures what the student passes into \code{\link{pass_if}} or \code{\link{fail_if}},
+Captures what the student passes into \code{\link[=pass_if]{pass_if()}} or \code{\link[=fail_if]{fail_if()}},
 figures out what type of object was passed into \code{x},
 and returns a \code{grader_condition} object that will be passed into
-\code{\link{evaluate_condition}}.
+\code{\link[=evaluate_condition]{evaluate_condition()}}.
 
-\code{pass_if} and \code{fail_if} are wrappers around \code{\link{condition}}
+\code{pass_if} and \code{fail_if} are wrappers around \code{\link[=condition]{condition()}}
 that sets the proper \code{correct} argument.
 This allows the instructor to specify just the comparison code, \code{x},
 and \code{message}.
@@ -79,5 +79,5 @@ check_result(
 )
 }
 \seealso{
-\code{\link{pass_if}}, \code{\link{fail_if}}, and \code{\link{condition}}
+\code{\link[=pass_if]{pass_if()}}, \code{\link[=fail_if]{fail_if()}}, and \code{\link[=condition]{condition()}}
 }

--- a/man/condition.Rd
+++ b/man/condition.Rd
@@ -4,7 +4,7 @@
 \alias{condition}
 \alias{pass_if}
 \alias{fail_if}
-\title{Condition object}
+\title{Condition object.}
 \usage{
 condition(x, message, correct)
 

--- a/man/evaluate_condition.Rd
+++ b/man/evaluate_condition.Rd
@@ -7,18 +7,18 @@
 evaluate_condition(condition, grader_args, learnr_args)
 }
 \arguments{
-\item{condition}{a \code{\link{condition}} object}
+\item{condition}{a \code{\link[=condition]{condition()}} object}
 
 \item{grader_args}{at minimum, a list that just contains the value for \code{solution_quo}}
 
 \item{learnr_args}{at minimum, a list that just contains the value for \code{envir_prep}}
 }
 \value{
-a \code{\link{graded}} value if \code{condi$x} is \code{TRUE} or
-  \code{NULL} if \code{condi$x} is \code{FALSE}
+a \code{\link[=graded]{graded()}} value if \code{condi$x} is \code{TRUE} or
+\code{NULL} if \code{condi$x} is \code{FALSE}
 }
 \description{
-Evaluates the \code{\link{condition}} object to return a \code{\link{graded}} value.
+Evaluates the \code{\link[=condition]{condition()}} object to return a \code{\link[=graded]{graded()}} value.
 }
 \examples{
  condi_formula_t <- condition(~ identical(.result, 5),

--- a/man/grade_learnr.Rd
+++ b/man/grade_learnr.Rd
@@ -32,14 +32,14 @@ chunk.}
 }
 \value{
 An R list which contains several fields indicating the result of the
-  check.
+check.
 }
 \description{
 For exercise checking, \code{learnr} tutorials require a function that
 \code{learnr} can use in the background to run the code in each "-check"
 chunk and to format the results into a format that \code{learnr} can display.
 The function must accept a specific set of inputs and return a specific type
-of output (see \code{\link{graded}}). Instructors are not intended to use the
+of output (see \code{\link[=graded]{graded()}}). Instructors are not intended to use the
 \code{grade_learnr} function directly, but to pass it to the
 \code{exercise.checker} knitr chunk option within the setup chunk of the
 \code{learnr} tutorial.

--- a/man/grading_demo.Rd
+++ b/man/grading_demo.Rd
@@ -13,11 +13,14 @@ file that demonstrates how to use the grader package to check student code.
 \details{
 The tutorial sets the learnr \code{exercise.checker} option to
 \code{grade_learnr()} in the document's setup chunk.
+
 It then uses three different exercise checking methods:
-\code{\link{check_result}}, \code{\link{test_result}}, and \code{\link{check_code}}.
+\code{\link[=check_result]{check_result()}}, \code{\link[=test_result]{test_result()}}, and \code{\link[=check_code]{check_code()}}.
+
 To use a checking method, follow the exercise chunk with a chunk whose label
 matches the label of the exercise chunk (ex: \code{myexercise}) but includes the suffix
 \code{-check} (ex: \code{myexercise-check}). Call any checking method in that chunk.
+
 To ensure that checking method can provide informative feedback,
 you may provide custom \code{correct} and \code{incorrect} messages.
 

--- a/man/praise.Rd
+++ b/man/praise.Rd
@@ -12,7 +12,7 @@ random_encourage()
 \description{
 Generate a random praise or encouragement phrase.
 This can be used in conjunction with
-\code{glue::\link[glue]{glue}} to generate praise or encouragement within feedback to users.
+\code{glue::[glue][glue::glue]} to generate praise or encouragement within feedback to users.
 }
 \section{Functions}{
 \itemize{

--- a/man/test_result.Rd
+++ b/man/test_result.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/test_result.R
 \name{test_result}
 \alias{test_result}
-\title{Test the result of exercise code}
+\title{Test the result of exercise code.}
 \usage{
 test_result(...,
   correct = "{num_correct}/{num_total} correct! {random_praise()}",
@@ -11,8 +11,8 @@ test_result(...,
 \arguments{
 \item{...}{ignored}
 
-\item{correct}{A character string to display if all tests pass.
-This character string will be run through \code{glue::[glue_data][glue::glue_data]} with
+\item{correct}{A character string to display if all tests pass. This
+character string will be run through \code{[glue::glue_data]} with:
 \itemize{
 \item \code{num_correct}: Number of correct tests. (Equals \code{num_total})
 \item \code{num_total}: Number of tests
@@ -20,29 +20,35 @@ This character string will be run through \code{glue::[glue_data][glue::glue_dat
 }}
 
 \item{incorrect}{A character string to display if at least one test fails.
-This character string will be run through \code{glue::[glue_data][glue::glue_data]} with
+This character string will be run through \code{][glue::glue_data]} with:
 \itemize{
 \item \code{num_correct}: Number of correct tests
 \item \code{num_total}: Number of tests
 \item \code{errors}: Vector of errors found
 }}
 
-\item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
-This contains: \describe{
-\item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-\item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{grader_args}{A list of parameters passed to \code{grader} functions
+(provided by \code{\link[=grade_learnr]{grade_learnr()}}). This contains:
+\itemize{
+\item \code{user_quo}: Quoted R code submitted by the user. For example
+\code{[rlang::quo](1)}
+\item \code{solution_quo}: (Optional) Quoted solution R code provided by the
+\code{*-solution} chunk for an exercise.
 }}
 
-\item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
-See \url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for more details.}
+\item{learnr_args}{A list of all parameters passed to \code{\link[=grade_learnr]{grade_learnr()}} by
+\code{learnr}. See
+\url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for
+more details.}
 }
 \value{
-a \code{grader_graded} structure from \code{\link[=graded]{graded()}} containing
-a formatted \code{correct} or \code{incorrect} message.
+a \code{grader_graded} structure from \code{\link[=graded]{graded()}} containing a formatted
+\code{correct} or \code{incorrect} message.
 }
 \description{
-\code{test_result()} executes tests against the final result of the user code.
-If a test throws an error, the test fails and the submitted answer will be marked incorrect.
+Executes tests against the final result of the user code. If
+a test throws an error, the test fails and the submitted answer will be
+marked incorrect.
 }
 \examples{
 \dontrun{grading_demo()}

--- a/man/test_result.Rd
+++ b/man/test_result.Rd
@@ -12,33 +12,33 @@ test_result(...,
 \item{...}{ignored}
 
 \item{correct}{A character string to display if all tests pass.
-  This character string will be run through \code{glue::\link[glue]{glue_data}} with
+This character string will be run through \code{glue::[glue_data][glue::glue_data]} with
 \itemize{
-  \item \code{num_correct}: Number of correct tests. (Equals \code{num_total})
-  \item \code{num_total}: Number of tests
-  \item \code{errors}: Vector of errors found. (\code{NULL})
+\item \code{num_correct}: Number of correct tests. (Equals \code{num_total})
+\item \code{num_total}: Number of tests
+\item \code{errors}: Vector of errors found. (\code{NULL})
 }}
 
 \item{incorrect}{A character string to display if at least one test fails.
-  This character string will be run through \code{glue::\link[glue]{glue_data}} with
+This character string will be run through \code{glue::[glue_data][glue::glue_data]} with
 \itemize{
-  \item \code{num_correct}: Number of correct tests
-  \item \code{num_total}: Number of tests
-  \item \code{errors}: Vector of errors found
+\item \code{num_correct}: Number of correct tests
+\item \code{num_total}: Number of tests
+\item \code{errors}: Vector of errors found
 }}
 
 \item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
 This contains: \describe{
- \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
- \item{\code{solution_quo}}{[Optional] Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
+\item{\code{solution_quo}}{\link{Optional} Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
 }}
 
 \item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.
 See \url{https://rstudio.github.io/learnr/exercises.html#exercise_checking} for more details.}
 }
 \value{
-a \code{grader_graded} structure from \code{\link{graded}} containing
-  a formatted \code{correct} or \code{incorrect} message.
+a \code{grader_graded} structure from \code{\link[=graded]{graded()}} containing
+a formatted \code{correct} or \code{incorrect} message.
 }
 \description{
 \code{test_result()} executes tests against the final result of the user code.

--- a/man/test_result.Rd
+++ b/man/test_result.Rd
@@ -30,7 +30,7 @@ This character string will be run through \code{glue::[glue_data][glue::glue_dat
 \item{grader_args}{A list of parameters passed to \code{grader} functions (provided by \code{\link{grade_learnr}}).
 This contains: \describe{
 \item{\code{user_quo}}{Quoted R code submitted by the user.  Ex: \code{rlang::\link[rlang]{quo}(1)} }
-\item{\code{solution_quo}}{\link{Optional} Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
+\item{\code{solution_quo}}{(Optional) Quoted solution R code provided by the \code{*-solution} chunk for an exercise.}
 }}
 
 \item{learnr_args}{A list of all parameters passed to \code{\link{grade_learnr}} by \code{learnr}.


### PR DESCRIPTION
Use roxygen markdown instead of traditional latex-like format.  Use @inheritParams instead of @template. Other small fixes to docs.