### PR TITLE
fix gradethis_demo, missed grader -> gradethis rename

### DIFF
--- a/R/gradethis_demo.R
+++ b/R/gradethis_demo.R
@@ -23,7 +23,7 @@
 #' @importFrom utils browseURL
 gradethis_demo <- function() {
   gradethis_demo_path <- system.file("tutorials", "grading-demo/grading-demo.Rmd",
-                                     package = "grader")
+                                     package = "gradethis")
   if (rstudioapi::isAvailable()) {
     rstudioapi::navigateToFile(gradethis_demo_path)
   } else {


### PR DESCRIPTION
Missed a `grader` -> `gradethis` rename

Fixes #80

In the meantime you can install the package via

```r
devtools::install_github('rstudio-education/gradethis@fix_gradethis_demo')
```