### PR TITLE
evaluate_condi_formula() should evaluate using envir_result

### DIFF
--- a/R/evaluate_condition.R
+++ b/R/evaluate_condition.R
@@ -23,7 +23,7 @@ evaluate_condition <- function(condition, grader_args, learnr_args) {
   err_msg <- NULL
   res <- tryCatch({
     switch(condition$type,
-           "formula" = evaluate_condi_formula(condition$x, learnr_args$last_value, learnr_args$envir_prep), # nolint
+           "formula" = evaluate_condi_formula(condition$x, learnr_args$last_value, learnr_args$envir_result), # nolint
            "function" = evaluate_condi_function(condition$x, learnr_args$last_value),
            "value" = evaluate_condi_value(condition$x, learnr_args$last_value)
          )

--- a/R/evaluate_condition.R
+++ b/R/evaluate_condition.R
@@ -21,9 +21,10 @@ evaluate_condition <- function(condition, grader_args, learnr_args) {
   checkmate::assert_class(condition, "grader_condition")
 
   err_msg <- NULL
+  envir <- learnr_args$envir_result %||% learnr_args$envir_prep %||% new.env()
   res <- tryCatch({
     switch(condition$type,
-           "formula" = evaluate_condi_formula(condition$x, learnr_args$last_value, learnr_args$envir_result), # nolint
+           "formula" = evaluate_condi_formula(condition$x, learnr_args$last_value, envir), # nolint
            "function" = evaluate_condi_function(condition$x, learnr_args$last_value),
            "value" = evaluate_condi_value(condition$x, learnr_args$last_value)
          )


### PR DESCRIPTION
Fixes #101
Fixes #121 

Before this change entering `a<-1` would result in a meaningless error. After this change, entering `a<-1` will pass the test

````
---
title: "Checking errors"
output: learnr::tutorial
runtime: shiny_prerendered
---

```{r setup, include=FALSE}
library(learnr)	
library(gradethis)
tutorial_options(
  exercise.checker = grade_learnr
)
```

* Please enter `a <- 1`

```{r grade_error, exercise = TRUE}

```


```{r grade_error-check}
grade_result(pass_if(~a==1))
```
````