### PR TITLE
Bump version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gradethis
 Type: Package
 Title: Tools for "grading" student exercises in learnr tutorials
-Version: 0.1.0.9002
+Version: 0.1.0.9004
 Authors@R: 
     c(person(given = "Daniel",
              family = "Chen",


### PR DESCRIPTION
9003 was used in this (closed) PR https://github.com/rstudio-education/gradethis/pull/115 so bumping to 9004 to avoid ambiguity.