### PR TITLE
Deploy grading demo and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ To view the latest grading demo of the different checking methods:
 library(gradethis)
 gradethis::gradethis_demo()
 ```
+
+You can also view a deployed version of this demo [here](https://minecr.shinyapps.io/gradethis_demo/).


### PR DESCRIPTION
This PR partially addresses #131 by adding a link to the deployed demo on the package README.