### PR TITLE
Issue 145

### DIFF
--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -123,10 +123,11 @@ grade_code <- function(
     .message = is_same_info$message,
     .incorrect = incorrect
   )
+  
   if (uses_pipe(user)) {
     message <- glue_message(
       glue_pipe,
-      .user = user,
+      .user = as.character(user),
       .message = message,
       .incorrect = incorrect
     )

--- a/R/unpipe.R
+++ b/R/unpipe.R
@@ -16,6 +16,13 @@ unpipe <- function(code) {
   lhs <- code[[2]]
   rhs <- code[[3]]
 
+  if (!is.call(rhs)){
+    # rhs need to be a call
+    # mainly because some user do `1 %>% print` instead of `1 %>% print()`
+    rhs <-  call(deparse(rhs))
+    }
+  
+  
   if (length(rhs) == 1) {
     rhs[[2]] <- lhs
     return(rhs)

--- a/R/unpipe.R
+++ b/R/unpipe.R
@@ -16,11 +16,11 @@ unpipe <- function(code) {
   lhs <- code[[2]]
   rhs <- code[[3]]
 
-  if (!is.call(rhs)){
+  if (!is.call(rhs)) {
     # rhs need to be a call
     # mainly because some user do `1 %>% print` instead of `1 %>% print()`
     rhs <-  call(deparse(rhs))
-    }
+  }
   
   
   if (length(rhs) == 1) {

--- a/tests/testthat/test_unpipe.R
+++ b/tests/testthat/test_unpipe.R
@@ -20,3 +20,20 @@ test_that("unpipe() does not alter unpiped code", {
 
   expect_equal(unpipe(func2), func2)
 })
+
+test_that("unpipe() can deal with missing parenthesis", {
+  pipe2 <- quote(1 %>% print)
+  func2 <- quote(print(1))
+  expect_equal(unpipe(pipe2), func2)
+  
+  
+
+})
+
+test_that("unpipe_all() can deal with missing parenthesis", {
+
+  pipe3 <- quote(iris %>% head %>% print)
+  func3 <- quote(print(head(iris)))
+  expect_equal(unpipe_all(pipe3), func3)
+  
+})


### PR DESCRIPTION
Fixes #145 

`unpipe` and `unpipe_all` can deal with missing parenthesis in call