### PR TITLE
fix #148 and road to 155

### DIFF
--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -1,4 +1,4 @@
-call_standardise_formals <- function(code, env = rlang::current_env(),minimalist = FALSE) {
+call_standardise_formals <- function(code, env = rlang::current_env(), include_defaults = TRUE) {
   # try to catch invalid function, i.e., corrupt language object
   tryCatch({
     fxn <- rlang::call_fn(code, env = env)
@@ -11,9 +11,9 @@ call_standardise_formals <- function(code, env = rlang::current_env(),minimalist
   
   
   
-  # standarise, but dont bother trying to fill out default formals
+  # if include_defaults == FALSE standarise, but dont bother trying to fill out default formals
   # - for primitives like mean, unable to distinguish between mean and mean.default
-  if (minimalist | (is_infix(code) || is.primitive(fxn))) {
+  if ( !include_defaults | (is_infix(code) || is.primitive(fxn))) {
     return(rlang::call_standardise(code))
   }
 

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -13,7 +13,7 @@ call_standardise_formals <- function(code, env = rlang::current_env(), include_d
   
   # if include_defaults == FALSE standarise, but dont bother trying to fill out default formals
   # - for primitives like mean, unable to distinguish between mean and mean.default
-  if ( !include_defaults | (is_infix(code) || is.primitive(fxn))) {
+  if ( (!include_defaults) || is_infix(code) || is.primitive(fxn)) {
     return(rlang::call_standardise(code))
   }
 

--- a/R/call_standarise_formals.R
+++ b/R/call_standarise_formals.R
@@ -1,5 +1,4 @@
-call_standardise_formals <- function(code, env = rlang::current_env()) {
-
+call_standardise_formals <- function(code, env = rlang::current_env(),minimalist = FALSE) {
   # try to catch invalid function, i.e., corrupt language object
   tryCatch({
     fxn <- rlang::call_fn(code, env = env)
@@ -9,9 +8,12 @@ call_standardise_formals <- function(code, env = rlang::current_env()) {
   if (!exists("fxn")) {return(code)} ## some reason the above tryCatch doesn't go to the error part
   if(class(fxn) != "function") {return(code)}
 
+  
+  
+  
   # standarise, but dont bother trying to fill out default formals
-  # for primitives like mean, unable to distinguish between mean and mean.default
-  if (is_infix(code) || is.primitive(fxn)) {
+  # - for primitives like mean, unable to distinguish between mean and mean.default
+  if (minimalist | (is_infix(code) || is.primitive(fxn))) {
     return(rlang::call_standardise(code))
   }
 

--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -242,8 +242,8 @@ detect_mistakes <- function(user,
   #    will tell them that it expected an na.rm argument, not that na is a surplus
   #    argument.
  
-  explicit_solution <-call_standardise_formals(unpipe_all(answer),env = env,minimalist = TRUE)
-  explicit_user <-call_standardise_formals(unpipe_all(submitted),env = env,minimalist = TRUE)
+  explicit_solution <-call_standardise_formals(unpipe_all(answer),env = env,include_defaults = FALSE)
+  explicit_user <-call_standardise_formals(unpipe_all(submitted),env = env,include_defaults = FALSE)
   explicit_user_names <- real_names(explicit_user)
   explicit_solution_names <-  real_names(explicit_solution)
   missing_args <- explicit_solution_names[!(explicit_solution_names %in% explicit_user_names)]

--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -49,7 +49,7 @@ detect_mistakes <- function(user,
   }
 
   submitted <- user
-  answer <- solution
+  solution_original <- solution
 
   if (is.call(user)) {
     user <- unpipe_all(user) # cannot standardise yet without risking error
@@ -242,7 +242,7 @@ detect_mistakes <- function(user,
   #    will tell them that it expected an na.rm argument, not that na is a surplus
   #    argument.
  
-  explicit_solution <-call_standardise_formals(unpipe_all(answer),env = env,include_defaults = FALSE)
+  explicit_solution <-call_standardise_formals(unpipe_all(solution_original),env = env,include_defaults = FALSE)
   explicit_user <- call_standardise_formals(
     unpipe_all(submitted),
     env = env,

--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -243,7 +243,11 @@ detect_mistakes <- function(user,
   #    argument.
  
   explicit_solution <-call_standardise_formals(unpipe_all(answer),env = env,include_defaults = FALSE)
-  explicit_user <-call_standardise_formals(unpipe_all(submitted),env = env,include_defaults = FALSE)
+  explicit_user <- call_standardise_formals(
+    unpipe_all(submitted),
+    env = env,
+    include_defaults = FALSE
+  )
   explicit_user_names <- real_names(explicit_user)
   explicit_solution_names <-  real_names(explicit_solution)
   missing_args <- explicit_solution_names[!(explicit_solution_names %in% explicit_user_names)]

--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -242,7 +242,11 @@ detect_mistakes <- function(user,
   #    will tell them that it expected an na.rm argument, not that na is a surplus
   #    argument.
  
-  explicit_solution <-call_standardise_formals(unpipe_all(solution_original),env = env,include_defaults = FALSE)
+  explicit_solution <- call_standardise_formals(
+    unpipe_all(solution_original),
+    env = env,
+    include_defaults = FALSE
+  )
   explicit_user <- call_standardise_formals(
     unpipe_all(submitted),
     env = env,

--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -49,6 +49,7 @@ detect_mistakes <- function(user,
   }
 
   submitted <- user
+  answer <- solution
 
   if (is.call(user)) {
     user <- unpipe_all(user) # cannot standardise yet without risking error
@@ -236,33 +237,41 @@ detect_mistakes <- function(user,
   }
 
 
-  # It is now safe to call call_standardise_formals on student code
-  user <- call_standardise_formals(user, env = env)
-  user_names <- real_names(user)
-
   # 5. Check that every named argument in the solution appears in the user code.
   #    The outcome of this order is that when a user writes na = TRUE, gradethis
   #    will tell them that it expected an na.rm argument, not that na is a surplus
   #    argument.
-  solution_names <-  real_names(solution) # original solution_names was modified above
-  missing_args <- solution_names[!(solution_names %in% user_names)]
+ 
+  explicit_solution <-call_standardise_formals(unpipe_all(answer),env = env,minimalist = TRUE)
+  explicit_user <-call_standardise_formals(unpipe_all(submitted),env = env,minimalist = TRUE)
+  explicit_user_names <- real_names(explicit_user)
+  explicit_solution_names <-  real_names(explicit_solution)
+  missing_args <- explicit_solution_names[!(explicit_solution_names %in% explicit_user_names)]
+
   if (length(missing_args) > 0) {
     missing_name <- missing_args[1]
     return(
       missing_argument(
-        this_call = solution,
+        this_call = explicit_solution,
         that_name = missing_name,
         enclosing_call = enclosing_call,
         enclosing_arg = enclosing_arg
       )
     )
   }
-
+  
+  # It is now safe to call call_standardise_formals on student code
+  user <- call_standardise_formals(user, env = env)
+  user_names <- real_names(user)
+  solution_names <-  real_names(solution) # original solution_names was modified above
+  
+  
   # 6. Check that the user code does not contain any named arguments that do not
   #    appear in the solution code. Since both calls have been standardised, these
   #    named arguments can only be being passed to ... and we should not match by
   #    position a named argument that is passed to ... with an unamed argument
   #    passed to ...
+
   unmatched_user_names <- user_names[!(user_names %in% solution_names)]
   if (length(unmatched_user_names) > 0) {
     surplus_name <- unmatched_user_names[1]

--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -126,7 +126,7 @@ grade_code <- function(
   if (uses_pipe(user)) {
     message <- glue_message(
       glue_pipe,
-      .user = user,
+      .user = as.character(user),
       .message = message,
       .incorrect = incorrect
     )

--- a/tests/testthat/test_standarize_call_formals.R
+++ b/tests/testthat/test_standarize_call_formals.R
@@ -64,3 +64,26 @@ test_that("When an invalid function passed (i.e., corrupt language object)", {
   testthat::expect_equal(
     call_standardise_formals(user), user)
 })
+
+
+test_that("Standarize call minimalist mode", {
+  library(readr)
+  user <- rlang::get_expr(quote(read_csv("foo.csv", skip = 3)))
+  user_stand <- gradethis:::call_standardise_formals(user)
+  user_stand_mini <- gradethis:::call_standardise_formals(user,minimalist = TRUE)
+  call("readr::read_csv", file = "foo.csv", skip = 3)
+  testthat::expect_equal(    user_stand_mini,
+                             call('read_csv', file = "foo.csv", skip = 3)
+                             )
+  testthat::expect_equal(    user_stand,
+                             quote(read_csv(file = "foo.csv", col_names = TRUE, col_types = NULL, 
+                                            locale = default_locale(), na = c("", "NA"), 
+                                            quoted_na = TRUE, quote = "\"", comment = "", 
+                                            trim_ws = TRUE, skip = 3, n_max = Inf, guess_max = min(1000, 
+                                            n_max), progress = show_progress(), skip_empty_rows = TRUE))
+                             )
+  
+  
+
+  
+})

--- a/tests/testthat/test_standarize_call_formals.R
+++ b/tests/testthat/test_standarize_call_formals.R
@@ -67,22 +67,16 @@ test_that("When an invalid function passed (i.e., corrupt language object)", {
 
 
 test_that("Standarize call with include_defaults = FALSE", {
-  library(readr)
-  user <- rlang::get_expr(quote(read_csv("foo.csv", skip = 3)))
+  library(purrr)
+  user <- rlang::get_expr(quote(insistently(mean,quiet = TRUE)))
   user_stand <- gradethis:::call_standardise_formals(user)
   user_stand_mini <- gradethis:::call_standardise_formals(user,include_defaults = FALSE)
   testthat::expect_equal(    user_stand_mini,
-                             call('read_csv', file = "foo.csv", skip = 3)
+                             quote(insistently(f = mean, quiet = TRUE))
                              )
   testthat::expect_equal(    user_stand,
-                             quote(read_csv(file = "foo.csv", col_names = TRUE, col_types = NULL, 
-                                            locale = default_locale(), na = c("", "NA"), 
-                                            quoted_na = TRUE, quote = "\"", comment = "", 
-                                            trim_ws = TRUE, skip = 3, n_max = Inf, guess_max = min(1000, 
-                                            n_max), progress = show_progress(), skip_empty_rows = TRUE))
+                             quote(insistently(f = mean,rate = rate_backoff(), quiet = TRUE))
                              )
   
-  
-
   
 })

--- a/tests/testthat/test_standarize_call_formals.R
+++ b/tests/testthat/test_standarize_call_formals.R
@@ -71,7 +71,6 @@ test_that("Standarize call minimalist mode", {
   user <- rlang::get_expr(quote(read_csv("foo.csv", skip = 3)))
   user_stand <- gradethis:::call_standardise_formals(user)
   user_stand_mini <- gradethis:::call_standardise_formals(user,minimalist = TRUE)
-  call("readr::read_csv", file = "foo.csv", skip = 3)
   testthat::expect_equal(    user_stand_mini,
                              call('read_csv', file = "foo.csv", skip = 3)
                              )

--- a/tests/testthat/test_standarize_call_formals.R
+++ b/tests/testthat/test_standarize_call_formals.R
@@ -66,11 +66,11 @@ test_that("When an invalid function passed (i.e., corrupt language object)", {
 })
 
 
-test_that("Standarize call minimalist mode", {
+test_that("Standarize call with include_defaults = FALSE", {
   library(readr)
   user <- rlang::get_expr(quote(read_csv("foo.csv", skip = 3)))
   user_stand <- gradethis:::call_standardise_formals(user)
-  user_stand_mini <- gradethis:::call_standardise_formals(user,minimalist = TRUE)
+  user_stand_mini <- gradethis:::call_standardise_formals(user,include_defaults = FALSE)
   testthat::expect_equal(    user_stand_mini,
                              call('read_csv', file = "foo.csv", skip = 3)
                              )


### PR DESCRIPTION
this fix #148 

the main action I made was to add a 'minimalist' parameter ( not sure about the name I choose) to force gradethis:::call_standardise_formals to not  fill out default formals. and I used `minimalist = TRUE` when detecting missing_args 

see : 
 ``` r
library(readr)
user <- rlang::get_expr(quote(read_csv("foo.csv", skip = 3)))
gradethis:::call_standardise_formals(user)
#> read_csv(file = "foo.csv", col_names = TRUE, col_types = NULL, 
#>     locale = default_locale(), na = c("", "NA"), quoted_na = TRUE, 
#>     quote = "\"", comment = "", trim_ws = TRUE, skip = 3, n_max = Inf, 
#>     guess_max = min(1000, n_max), progress = show_progress(), 
#>     skip_empty_rows = TRUE)
gradethis:::call_standardise_formals(user,minimalist = TRUE)
#> read_csv(file = "foo.csv", skip = 3)
```
