### PR TITLE
Allow for function definitions in `unpipe()`

### DIFF
--- a/R/message_generators.R
+++ b/R/message_generators.R
@@ -366,6 +366,8 @@ prep <- function(text) {
     text <- text[[1]]
   } else if (is.call(text)) {
     text <- text[1]
+  } else if (is.pairlist(text)) {
+    return(prep_function_arguments(text))
   }
   deparse_to_string(text)
 }
@@ -382,4 +384,13 @@ build_intro <- function(.call = NULL, .arg = NULL) {
     intro <- ""
   }
   intro
+}
+
+prep_function_arguments <- function(arg_list) {
+  args <- names(arg_list)
+  values <- purrr::map_chr(arg_list, function(arg_value) {
+    if (arg_value == quote("")) return("")
+    paste(" =", deparse(arg_value))
+  })
+  paste("arguments", paste0(args, values, collapse = ", "))
 }

--- a/R/message_generators.R
+++ b/R/message_generators.R
@@ -373,11 +373,16 @@ prep <- function(text) {
 }
 
 build_intro <- function(.call = NULL, .arg = NULL) {
+  is_call_fn_def <- is_function_definition(.call)
 
   if(!is.null(.call)) {
     .call <- deparse_to_string(.call)
     if (!is.null(.arg) && !identical(.arg, "")) {
       .call <- paste(.arg, "=", .call)
+    } 
+    if (is_call_fn_def) {
+      # strip function body
+      .call <- sub("^(function\\(.+?\\))(.+)$", "\\1", .call)
     }
     intro <- glue::glue("In {.call}, ")
   } else {

--- a/R/unpipe.R
+++ b/R/unpipe.R
@@ -43,8 +43,10 @@ is_dot <- function(name) {
 }
 
 unpipe_all <- function(code_expr) {
-  if (length(code_expr) == 1) return(code_expr)
-  if (length(code_expr) == 2 && is.null(code_expr[[2]])) return(code_expr)
+  code_expr_len <- length(code_expr)
+  if (code_expr_len == 0) return(code_expr)
+  if (code_expr_len == 1) return(code_expr)
+  if (code_expr_len == 2 && is.null(code_expr[[2]])) return(code_expr)
   code_expr <- as.call(purrr::map(as.list(code_expr), unpipe_all))
   unpipe(code_expr)
 }

--- a/R/unpipe.R
+++ b/R/unpipe.R
@@ -47,6 +47,7 @@ unpipe_all <- function(code_expr) {
   if (code_expr_len == 0) return(code_expr)
   if (code_expr_len == 1) return(code_expr)
   if (code_expr_len == 2 && is.null(code_expr[[2]])) return(code_expr)
+  if (length(code_expr) == 4 && code_expr[[1]] == "function") return(code_expr)
   code_expr <- as.call(purrr::map(as.list(code_expr), unpipe_all))
   unpipe(code_expr)
 }

--- a/tests/testthat/test_detect_mistakes.R
+++ b/tests/testthat/test_detect_mistakes.R
@@ -824,3 +824,39 @@ test_that("detect_mistakes : Differentiate between 'strings' and objects in mess
   )
 
 })
+
+
+test_that("detect_mistakes works with function arguments", {
+  expect_equal(
+    detect_mistakes(as.pairlist(alist(x = , y = )), as.pairlist(alist(x = , y = , z =))),
+    "I expected arguments x, y, z where you wrote arguments x, y." 
+  )
+  
+  expect_grade_code(
+    user_code = "function(x, y, z) x + y",
+    solution_code = "function(x, y) x + y",
+    is_correct = FALSE,
+    msg = "In function(x, y, z) x + y, I expected arguments x, y where you wrote arguments x, y, z."
+  )
+  
+  expect_grade_code(
+    user_code = "function(x, y) x + y", 
+    solution_code = "function(y, x) x + y",
+    is_correct = FALSE,
+    msg = "In function(x, y) x + y, I expected arguments y, x where you wrote arguments x, y."
+  )
+  
+  expect_grade_code(
+    user_code = "function(x, y) x + y", 
+    solution_code = "function(x, y = 1) x + y",
+    is_correct = FALSE,
+    msg = "In function(x, y) x + y, I expected arguments x, y = 1 where you wrote arguments x, y."
+  )
+  
+  expect_grade_code(
+    user_code = "function(x = 1, y = 2) x + y", 
+    solution_code = "function(x, y = 1) x + y",
+    is_correct = FALSE,
+    msg = "In function(x = 1, y = 2) x + y, I expected arguments x, y = 1 where you wrote arguments x = 1, y = 2."
+  )
+})

--- a/tests/testthat/test_detect_mistakes.R
+++ b/tests/testthat/test_detect_mistakes.R
@@ -836,27 +836,37 @@ test_that("detect_mistakes works with function arguments", {
     user_code = "function(x, y, z) x + y",
     solution_code = "function(x, y) x + y",
     is_correct = FALSE,
-    msg = "In function(x, y, z) x + y, I expected arguments x, y where you wrote arguments x, y, z."
+    msg = "In function(x, y, z), I expected arguments x, y where you wrote arguments x, y, z."
   )
   
   expect_grade_code(
     user_code = "function(x, y) x + y", 
     solution_code = "function(y, x) x + y",
     is_correct = FALSE,
-    msg = "In function(x, y) x + y, I expected arguments y, x where you wrote arguments x, y."
+    msg = "In function(x, y), I expected arguments y, x where you wrote arguments x, y."
   )
   
   expect_grade_code(
     user_code = "function(x, y) x + y", 
     solution_code = "function(x, y = 1) x + y",
     is_correct = FALSE,
-    msg = "In function(x, y) x + y, I expected arguments x, y = 1 where you wrote arguments x, y."
+    msg = "In function(x, y), I expected arguments x, y = 1 where you wrote arguments x, y."
   )
   
   expect_grade_code(
     user_code = "function(x = 1, y = 2) x + y", 
     solution_code = "function(x, y = 1) x + y",
     is_correct = FALSE,
-    msg = "In function(x = 1, y = 2) x + y, I expected arguments x, y = 1 where you wrote arguments x = 1, y = 2."
+    msg = "In function(x = 1, y = 2), I expected arguments x, y = 1 where you wrote arguments x = 1, y = 2."
+  )
+  
+  expect_equal(
+    code_feedback("function(x, y = a1 %>% b) x + y", "function(x, y = b(a)) x + y"),
+    "In function(x, y = a1 %>% b), I expected arguments x, y = b(a) where you wrote arguments x, y = b(a1)."
+  )
+  
+  expect_equal(
+    code_feedback("function(x, y) y2 %>% x", "function(x, y) y %>% x"),
+    "In x(y2), I expected y where you wrote y2."
   )
 })

--- a/tests/testthat/test_unpipe.R
+++ b/tests/testthat/test_unpipe.R
@@ -37,3 +37,11 @@ test_that("unpipe_all() can deal with missing parenthesis", {
   expect_equal(unpipe_all(pipe3), func3)
   
 })
+
+test_that("unpipe_all() can deal with function definitions", {
+  function1 <- quote(function(x, y) x + y)
+  function2 <- quote(add <- function(x, y) x + y)
+  
+  expect_equal(unpipe_all(function1), function1)
+  expect_equal(unpipe_all(function2), function2)
+})


### PR DESCRIPTION
Fixes #177 
Fixes #179 

While it doesn't make for a great user feedback message, at least it isn't failing to provide a feedback message.

Prior:
```
# failing
code_feedback("function(x, y, z) x + y", "function(x, y) x + y")
#> Error in as.call(purrr::map(as.list(code_expr), unpipe_all)) :
#>   invalid length 0 argument
```

With PR:
```r
# ugly feedback, but not failing
code_feedback("function(x, y, z) x + y", "function(x, y) x + y")
#> In function(x, y, z) x + y, I did not expect your call to () to include z = . You may have included an unnecessary argument, or you may have left out or misspelled an important argument name.

# ugly feedback, but not failing
code_feedback("function(x, y) x + y", "function(y, x) x + y")
#> In function(x, y) x + y, I did not expect your call to () to include y = . You may have included an unnecessary argument, or you may have left out or misspelled an important argument name.
```

cc @gvwilson 