### PR TITLE
code_feedback() can accept character vectors

### DIFF
--- a/R/grade_this_code.R
+++ b/R/grade_this_code.R
@@ -178,7 +178,7 @@ to_expr <- function(x, name) {
   if (rlang::is_quosure(x)) {
     rlang::get_expr(x)
   } else {
-    chkm8_single_character(x, null.ok = FALSE, name = name)
+    checkmate::assert_character(x, null.ok = FALSE, min.len = 1L, .var.name = name)
     str2expression(x)
   }
 }

--- a/tests/testthat/test_check_code.R
+++ b/tests/testthat/test_check_code.R
@@ -106,6 +106,18 @@ test_that("Returns intelligent error when no user code", {
   )
 })
 
+test_that("code_feedback() can handle character vectors", {
+  expect_grade_code(
+    user_code = c("1", "3"),
+    solution_code = c("1", "2"),
+    is_correct = FALSE,
+    msg = "I expected 2 where you wrote 3."
+  )
+  expect_null(code_feedback(c("1", "2"), c("1", "2")))
+  expect_error(code_feedback("1", NULL))
+  expect_error(code_feedback("1", character()))
+})
+
 test_that("Spot differences when pipes are involved", {
 
   select <- function(df, x) {


### PR DESCRIPTION
Fixes #181

I changed the assertion check in `to_expr()` to check for non-NULL and length > 0 character vectors (or a quosure).
