### PR TITLE
Adds unpipe_all_str() that returns unpiped code as string

### DIFF
--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -141,6 +141,9 @@ grade_code <- function(
 
     # add pipe message
     if (uses_pipe(user_code)) {
+      # find first expression containing pipes
+      # user_piped_expr <- filter_pipe_expr(user_code)[[1]]
+      
       message <- glue_message(
         glue_pipe,
         # convert forwards and backwards to apply consistent formatting

--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -141,9 +141,6 @@ grade_code <- function(
 
     # add pipe message
     if (uses_pipe(user_code)) {
-      # find first expression containing pipes
-      # user_piped_expr <- filter_pipe_expr(user_code)[[1]]
-      
       message <- glue_message(
         glue_pipe,
         # convert forwards and backwards to apply consistent formatting

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,7 +24,8 @@ gradethis_default_options <- list(
   gradethis_glue_pipe = paste0(
     "I see that you are using pipe operators (e.g. %>%), ",
     "so I want to let you know that this is how I am interpretting your code ",
-    "before I check it:\n\n{deparse_to_string(unpipe_all(.user), 60)}\n\n{.message}"),
+    "before I check it:\n\n{unpipe_all_str(.user, width = 60)}\n\n{.message}"
+  ),
 
   gradethis_glue_correct_test = "{ .num_correct }/{ .num_total } correct! { random_praise() }",
   gradethis_glue_incorrect_test = "{ .num_correct }/{ .num_total } correct! { random_encourage() }"

--- a/tests/testthat/test_unpipe.R
+++ b/tests/testthat/test_unpipe.R
@@ -45,3 +45,31 @@ test_that("unpipe_all() can deal with function definitions", {
   expect_equal(unpipe_all(function1), function1)
   expect_equal(unpipe_all(function2), function2)
 })
+
+test_that("unpipe_all() accepts code as strings", {
+  pipe_str <- "a %>% b(x = 1) %>% c(y = 2)"
+  pipe_quo <- quote(a %>% b(x = 1) %>% c(y = 2))
+  unpipe_quo <- quote(c(b(a, x = 1), y = 2))
+  
+  expect_equal(unpipe_all(pipe_str), unpipe_all(pipe_quo))
+  expect_equal(unpipe_all_str(pipe_str), unpipe_all_str(pipe_quo))
+  expect_equal(unpipe_all_str(pipe_str), rlang::quo_text(unpipe_quo))
+  
+  # unpipe_all can receive strings with multiple expressions
+  pipe_str2 <- "d %>% e(x = 1) %>% f(y = 2)"
+  pipe_quo2 <- quote(d %>% e(x = 1) %>% f(y = 2))
+  unpipe_quo2 <- quote(f(e(d, x = 1), y = 2))
+  
+  expect_equal(
+    unpipe_all(paste0(pipe_str, "\n", pipe_str2)),
+    purrr::map(list(pipe_quo, pipe_quo2), unpipe_all)
+  )
+  expect_equal(
+    unpipe_all_str(paste0(pipe_str, "\n", pipe_str2), collapse = NULL),
+    purrr::map_chr(list(pipe_quo, pipe_quo2), unpipe_all_str)
+  )
+  expect_equal(
+    unpipe_all_str(paste0(pipe_str, "\n", pipe_str2)),
+    paste(c(rlang::quo_text(unpipe_quo), rlang::quo_text(unpipe_quo2)), collapse = "\n")
+  )
+})

--- a/tests/testthat/test_zzzz-check_code.R
+++ b/tests/testthat/test_zzzz-check_code.R
@@ -253,3 +253,24 @@ test_that("Spots differences in long calls", {
     is_correct = TRUE
   )
 })
+
+test_that("glue_pipe message returns unpiped text", {
+  user_code <- "x %>% a() %>% b() %>% c()"
+  expect_grade_code(
+    user_code = user_code,
+    solution_code = "b(a(x))",
+    is_correct = FALSE,
+    glue_pipe = "{unpipe_all_str(.user)}",
+    msg = unpipe_all_str(user_code)
+  )
+  
+  with_options(
+    list(gradethis.glue_pipe = gradethis_default_options$gradethis_glue_pipe),
+    expect_grade_code(
+      user_code = user_code,
+      solution_code = "b(a(x))",
+      is_correct = FALSE,
+      msg = glue_message(gradethis_default_options$gradethis_glue_pipe, .user = user_code, .message = "")
+    )
+  )
+})


### PR DESCRIPTION
Adds a function `unpipe_all_str()` that returns unpiped code as a string. The `_str` reflects the guarantee that the unpiped result will be returned as a character.

```r
unpipe_all_str("mtcars %>% filter(cyl < 6) %>% select(mpg, cyl, hp)")
#> [1] "select(filter(mtcars, cyl < 6), mpg, cyl, hp)"

unpipe_all_str("as.data.frame(mtcars %>% filter(cyl < 6) %>% select(mpg, cyl, hp))")
#> [1] "as.data.frame(select(filter(mtcars, cyl < 6), mpg, cyl, hp))"
```

If the code contains more than one expression, the default is `collapse = "\n"`. `collapse` can be set to `NULL` to get a character vector.

```r
unpipe_all_str(
  paste(
    "mtcars %>% filter(cyl < 6) %>% select(mpg, cyl, hp)",
    "mtcars %>% group_by(cyl) %>% summarize(wt = mean(wt))",
    sep = "\n"
  )
)
#> [1] "select(filter(mtcars, cyl < 6), mpg, cyl, hp)\nsummarize(group_by(mtcars, cyl), wt = mean(wt))"
```

`unpipe_all()` gains the ability to accept a character vector as well, but the difference is that it returns a list of calls if more than one expression is provided.

```r
unpipe_all("mtcars %>% filter(cyl < 6) %>% select(mpg, cyl, hp)")
#> select(filter(mtcars, cyl < 6), mpg, cyl, hp)
unpipe_all(
  paste(
    "mtcars %>% filter(cyl < 6) %>% select(mpg, cyl, hp)",
    "mtcars %>% group_by(cyl) %>% summarize(wt = mean(wt))",
    sep = "\n"
  )
)
#> [[1]]
#> select(filter(mtcars, cyl < 6), mpg, cyl, hp)
#> 
#> [[2]]
#> summarize(group_by(mtcars, cyl), wt = mean(wt))
```

`unpipe_all_str()` can equally handle a call, so in the typical use case the only difference between the two is that `unpipe_all_str()` returns a character vector.

```r
unpipe_all_str(quote(mtcars %>% filter(cyl < 6) %>% select(mpg, cyl, hp)))
#> [1] "select(filter(mtcars, cyl < 6), mpg, cyl, hp)"
unpipe_all(quote(mtcars %>% filter(cyl < 6) %>% select(mpg, cyl, hp)))
#> select(filter(mtcars, cyl < 6), mpg, cyl, hp)
```

All of this is to fix #93 so that the user code, a string in `glue_message()`, can be unpiped. The default `gradethis.glue_pipe` message has been updated.

```r
grade_code()(list2env(list(
  .user_code = "x %>% a() %>% b()",
  .solution_code = "x %>% b() %>% c()"
)))
#> <gradethis_graded: Incorrect: I see that you are using pipe operators (e.g. %>%), so I want to let you know that this is how I am interpretting your code before I check it:
#> 
#> b(a(x))
#> 
#> I expected you to call c() where you called b().  Try it again. You get better each time.>
```