### PR TITLE
Fixes grade_this() examples in docs

### DIFF
--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -37,7 +37,7 @@
 #'   pass_if_equal(5, "You got 5, great!")
 #'   fail()
 #' })(list(
-#'   .last_value = 4
+#'   .result = 4
 #' ))
 #'
 #' grade_this({
@@ -45,7 +45,7 @@
 #'   testthat::expect_equal(.result, 5L)        # will `fail()` if not equal to 5
 #'   pass() # returns default message
 #' })(list(
-#'   .last_value = 5L
+#'   .result = 5L
 #' ))
 #'
 #' grade_this({
@@ -53,7 +53,7 @@
 #'   testthat::expect_equal(.result(1), 3)
 #'   pass()
 #' })(list(
-#'   .last_value = function(x) {x + 2}
+#'   .result = function(x) {x + 2}
 #' ))
 #'
 #' # Remember, only `grade_this(expr)` should be used.
@@ -68,6 +68,9 @@ grade_this <- function(
   express <- rlang::get_expr(rlang::enquo(expr))
 
   function(checking_env) {
+    if (is.list(checking_env)) {
+      checking_env <- list2env(checking_env)
+    }
 
     # make sure fail calls can get code feed back (or not) if they want
     with_code_feedback(

--- a/man/grade_this.Rd
+++ b/man/grade_this.Rd
@@ -56,7 +56,7 @@ grade_this({
   pass_if_equal(5, "You got 5, great!")
   fail()
 })(list(
-  .last_value = 4
+  .result = 4
 ))
 
 grade_this({
@@ -64,7 +64,7 @@ grade_this({
   testthat::expect_equal(.result, 5L)        # will `fail()` if not equal to 5
   pass() # returns default message
 })(list(
-  .last_value = 5L
+  .result = 5L
 ))
 
 grade_this({
@@ -72,7 +72,7 @@ grade_this({
   testthat::expect_equal(.result(1), 3)
   pass()
 })(list(
-  .last_value = function(x) {x + 2}
+  .result = function(x) {x + 2}
 ))
 
 # Remember, only `grade_this(expr)` should be used.


### PR DESCRIPTION
The `grade_this()` examples indicate that something like this should work:

```r
grade_this({
  fail_if_equal(4, "Try adding 1")
  pass_if_equal(5, "You got 5, great!")
  fail()
})(list(
  .last_value = 4
))
#> <gradethis_graded: Incorrect: 'enclos' must be an environment>
```

but it doesn't work as expected for two reasons:

- If the `checking_env` isn't an environment, an error is thrown (and captured so it isn't immediately obvious)
- The checking conditions all require `.result`, not `.last_value`.

It's easy enough to promote the checking_env list to an env with `list2env()`, but there's already a lot of extra syntax around these functions so I added a small step to promote a list to an env before calling `with_code_feedback()`.

And I've updated the examples to reference `.result` instead of `.last_value`.

```r
grade_this({
  fail_if_equal(4, "Try adding 1")
  pass_if_equal(5, "You got 5, great!")
  fail()
})(list(
  .result = 4
))
#> <gradethis_graded: Incorrect: Try adding 1>
```