### PR TITLE
Promote lists to envs in grade_code() as well

### DIFF
--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -94,6 +94,9 @@ grade_code <- function(
 
   # return script style function
   function(check_env) {
+    if (is.list(check_env)) {
+      check_env <- list2env(check_env)
+    }
 
     user_code <- check_env$.user_code
     if (is.null(user_code)) {

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -67,9 +67,9 @@ grade_this <- function(
 ) {
   express <- rlang::get_expr(rlang::enquo(expr))
 
-  function(checking_env) {
-    if (is.list(checking_env)) {
-      checking_env <- list2env(checking_env)
+  function(check_env) {
+    if (is.list(check_env)) {
+      check_env <- list2env(check_env)
     }
 
     # make sure fail calls can get code feed back (or not) if they want
@@ -82,7 +82,7 @@ grade_this <- function(
         # force the evaluation of the expression in an environment
         rlang::eval_tidy(
           express,
-          env = checking_env
+          env = check_env
         )
       })
     )

--- a/R/grade_this_code.R
+++ b/R/grade_this_code.R
@@ -74,16 +74,16 @@ grade_this_code <- function(
   ellipsis::check_dots_empty()
 
   # MUST wrap calling function to be able to shim in `.correct`/`.incorrect`
-  function(checking_env) {
-    checking_env[[".__correct"]] <- correct
-    checking_env[[".__incorrect"]] <- incorrect
+  function(check_env) {
+    check_env[[".__correct"]] <- correct
+    check_env[[".__incorrect"]] <- incorrect
 
     grade_this(
       fail_code_feedback = fail_code_feedback,
       expr = {
         # create variable `.message` for glue to find
         .message <- code_feedback(allow_partial_matching = allow_partial_matching)
-        # call `pass`/`fail` inside `grade_this` to have access to `checking_env`
+        # call `pass`/`fail` inside `grade_this` to have access to `check_env`
         if (is.null(.message)) {
           # need to use `get()` to avoid using `utils::globalVariables`
           pass(get(".__correct"))
@@ -91,7 +91,7 @@ grade_this_code <- function(
           fail(get(".__incorrect"))
         }
       }
-    )(checking_env)
+    )(check_env)
   }
 }
 


### PR DESCRIPTION
- Promote lists to envs in grade_code(), pairs with #188
- Rename `checking_env` -> `check_env` for consistency
