### PR TITLE
Use unpiped submission in detect_mistakes() where possible

### DIFF
--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -324,8 +324,10 @@ detect_mistakes <- function(user,
   for (name in solution_names) {
     if (!identical(user[[name]], solution[[name]])) {
       arg_name <- ifelse(name %in% submitted_names, name, "")
+      # recover the user submission as provided by only unpiping one level
+      user_submitted <- call_standardise_formals(unpipe(submitted))
       res <- detect_mistakes(
-        user = user[[name]],
+        user = user_submitted[[name]],
         solution = solution[[name]],
         env = env,
         # If too verbose, use user[1]
@@ -391,7 +393,8 @@ detect_mistakes <- function(user,
       name <- rlang::names2(user_args[i])
       if (!(name %in% submitted_names)) name <- ""
       res <- detect_mistakes(
-        user = user_args[[i]],
+        # unpipe only one level to detect mistakes in the argument as submitted
+        user = unpipe(submitted)[[i + 1]],
         solution = solution_args[[i]],
         env = env,
         # If too verbose, use user[1]

--- a/R/message_generators.R
+++ b/R/message_generators.R
@@ -372,7 +372,7 @@ prep <- function(text) {
   # investigation for a cleaner solution.
   if (is_infix(text)) {
     text <- text[[1]]
-  } else if (is.call(text)) {
+  } else if (is.call(text) && !is_pipe(text)) {
     text <- text[1]
   } else if (is.pairlist(text)) {
     return(prep_function_arguments(text))

--- a/tests/testthat/test_detect_mistakes.R
+++ b/tests/testthat/test_detect_mistakes.R
@@ -454,15 +454,16 @@ test_that("detect_mistakes works with infix operators", {
 })
 
 test_that("detect_mistakes works with pipes", {
-
+  
   # internal pipe
   user <-     quote(b(1 %>% abs()))
   solution <- quote(b(1))
   expect_equal(
     detect_mistakes(user, solution),
-    wrong_value(this = user[[2]][[3]], that = solution[[2]], enclosing_call = user)
+    wrong_value(this = user[[2]], that = solution[[2]], enclosing_call = user)
+    # "In `b(1 %>% abs())`, I expected `1` where you wrote `1 %>% abs()`."
   )
-
+  
   user <-     quote(sqrt(1))
   solution <- quote(sqrt(1 %>% log()))
   expect_equal(
@@ -862,11 +863,11 @@ test_that("detect_mistakes works with function arguments", {
   
   expect_equal(
     code_feedback("function(x, y = a1 %>% b) x + y", "function(x, y = b(a)) x + y"),
-    "In `function(x, y = a1 %>% b)`, I expected arguments `x`, `y = b(a)` where you wrote arguments `x`, `y = b(a1)`."
+    "In `function(x, y = a1 %>% b)`, I expected arguments `x`, `y = b(a)` where you wrote arguments `x`, `y = a1 %>% b`."
   )
   
   expect_equal(
     code_feedback("function(x, y) y2 %>% x", "function(x, y) y %>% x"),
-    "In `x(y2)`, I expected `y` where you wrote `y2`."
+    "In `y2 %>% x`, I expected `y` where you wrote `y2`."
   )
 })


### PR DESCRIPTION
Fixes #98

`detect_mistakes()` recurses through the submitted expression, but always unpipes the submission before detecting mistakes. In two key places we can recurse on the original submission instead of the unpiped expression. The trick is to call `unpipe(submitted)` to unpipe only the first level of the submitted expression so that we can align our position in the unpiped expression with the original submission.

### Before

``` r
user <-     quote(b(1 %>% abs()))
solution <- quote(b(1))
detect_mistakes(user, solution)
#> In `b(1 %>% abs())`, I expected `1` where you wrote `abs()`.

code_feedback("function(x, y = a1 %>% b) x + y", "function(x, y = b(a)) x + y")
#> In `function(x, y = a1 %>% b)`, I expected arguments `x`, `y = b(a)` 
#> where you wrote arguments `x`, `y = b(a1)`.

code_feedback("function(x, y) y2 %>% x", "function(x, y) y %>% x")
#> In `x(y2)`, I expected `y` where you wrote `y2`.
```

### Now

```r
user <-     quote(b(1 %>% abs()))
solution <- quote(b(1))
detect_mistakes(user, solution)
#> In `b(1 %>% abs())`, I expected `1` where you wrote `1 %>% abs()`.

code_feedback("function(x, y = a1 %>% b) x + y", "function(x, y = b(a)) x + y")
#> In `function(x, y = a1 %>% b)`, I expected arguments `x`, `y = b(a)`
#> where you wrote arguments `x`, `y = a1 %>% b`.

code_feedback("function(x, y) y2 %>% x", "function(x, y) y %>% x")
#> In `y2 %>% x`, I expected `y` where you wrote `y2`.
```