### PR TITLE
Don't HTML escape protected messages in gradethis, let learnr handle bare string

### DIFF
--- a/R/feedback.R
+++ b/R/feedback.R
@@ -59,7 +59,7 @@ message_md <- function(message = NULL) {
   }
   if (is_AsIs(message)) {
     # AsIs messages are collapsed with new lines to match markdown_html()
-    return(htmltools::htmlEscape(paste(message, collapse = "\n")))
+    return(paste(message, collapse = "\n"))
   }
   if (is.null(message)) {
     return("")

--- a/tests/testthat/test-feedback.R
+++ b/tests/testthat/test-feedback.R
@@ -46,13 +46,13 @@ test_that("markdown: AsIs text is returned untouched", {
   
   expect_equal(glue_message_with_env(env, txt), txt)
   expect_equal(glue_message(txt, one = "1", two = "2"), txt)
-  expect_equal(message_md(txt), "__{one}__ &lt;em&gt;{two}&lt;/em&gt;")
+  expect_equal(message_md(txt), "__{one}__ <em>{two}</em>")
 })
 
 test_that("markdown: disallowed tags are escaped", {
   expect_match(message_md("<script>alert('boo')</script>"), "&lt;script")
   expect_match(message_md("<style></style>"), "&lt;style")
-  expect_match(message_md(I("<style></style>")), "&lt;style&gt;&lt;/style&gt;")
+  expect_match(message_md(I("<style></style>")), "<style></style>")
 })
 
 test_that("markdown: grading functions handle HTML messages", {


### PR DESCRIPTION
After testing a bit, I think it's overly zealous for gradethis to HTML-escape regular character strings. learnr already does this when handling bare strings, so we'd need to add `htmltools::HTML()` to avoid that or just give learnr the character message. I prefer the latter.