### PR TITLE
Skip the code feedback intro if it's too long

### DIFF
--- a/R/message_generators.R
+++ b/R/message_generators.R
@@ -384,15 +384,19 @@ build_intro <- function(.call = NULL, .arg = NULL) {
   is_call_fn_def <- is_function_definition(.call)
 
   if(!is.null(.call)) {
-    .call <- deparse_to_string(.call)
+    .call_str <- deparse_to_string(.call)
     if (!is.null(.arg) && !identical(.arg, "")) {
-      .call <- paste(.arg, "=", .call)
+      .call_str <- paste(.arg, "=", .call_str)
     } 
     if (is_call_fn_def) {
       # strip function body
-      .call <- sub("^(function\\(.+?\\))(.+)$", "\\1", .call)
+      .call_str <- sub("^(function\\(.+?\\))(.+)$", "\\1", .call_str)
     }
-    intro <- glue::glue("In `{.call}`, ")
+    if (nchar(.call_str) > 80) {
+      # too much context, the intro is too long to be helpful
+      return("")
+    }
+    intro <- glue::glue("In `{.call_str}`, ")
   } else {
     intro <- ""
   }

--- a/tests/testthat/test_detect_mistakes.R
+++ b/tests/testthat/test_detect_mistakes.R
@@ -871,3 +871,20 @@ test_that("detect_mistakes works with function arguments", {
     "In `y2 %>% x`, I expected `y` where you wrote `y2`."
   )
 })
+
+
+test_that("detect_mistakes returns a reasonable amount of intro context", {
+  ggplot_1 <- 'ggplot(data = penguins, mapping = aes(x = flipper_length_mm, fill = species)) +
+    geom_density(alpha = 0.4) + 
+    labs(title = "Gentoos have the longest flippers", x = "Flipper length (mm)", y = "Density") + 
+    scale_color_brewer(palette = "Set1")'
+  ggplot_2 <- 'ggplot(data = penguins, mapping = aes(x = flipper_length_mm, fill = species)) +
+    geom_density(alpha = 0.4) + 
+    labs(title = "Gentoos have the longest flippers", x = "Flipper length (mm)", y = "Density") + 
+    scale_fill_brewer(palette = "Set1")'
+  
+  feedback <- code_feedback(ggplot_1, ggplot_2)
+  expect_false(grepl("^In ", feedback))
+  expect_match(feedback, "scale_color_brewer", fixed = TRUE)
+  expect_match(feedback, "scale_fill_brewer", fixed = TRUE)
+})


### PR DESCRIPTION
Fixes #202

If it's more than 80 characters, it's too long for the markdown text to be actually helpful. 80 characters is probably high but anything larger is definitely too much context.

### Before

```r
ex <- mock_this_exercise(
  'ggplot(data = penguins, mapping = aes(x = flipper_length_mm, fill = species)) +
    geom_density(alpha = 0.4) + 
    labs(title = "Gentoos have the longest flippers", x = "Flipper length (mm)", y = "Density") + 
    scale_color_brewer(palette = "Set1")',
  'ggplot(data = penguins, mapping = aes(x = flipper_length_mm, fill = species)) +
    geom_density(alpha = 0.4) + 
    labs(title = "Gentoos have the longest flippers", x = "Flipper length (mm)", y = "Density") + 
    scale_fill_brewer(palette = "Set1")'
)

code_feedback(ex$.user_code, ex$.solution_code)
```

> In `ggplot(data = penguins, mapping = aes(x = flipper_length_mm, fill = species)) + geom_density(alpha = 0.4) + labs(title = "Gentoos have the longest flippers", x = "Flipper length (mm)", y = "Density") + scale_color_brewer(palette = "Set1")`, I expected you to call `scale_fill_brewer()` where you called `scale_color_brewer()`.

### After 

```r
code_feedback(ex$.user_code, ex$.solution_code)
```

> I expected you to call `scale_fill_brewer()` where you called `scale_color_brewer()`.