### PR TITLE
fix: Handle a mix of named and unnamed arguments and with pipes

### DIFF
--- a/R/detect_mistakes.R
+++ b/R/detect_mistakes.R
@@ -65,6 +65,11 @@ detect_mistakes <- function(user,
   # BUT WHAT IF ONE IS A CALL THAT EVALUATES TO THE VALUE OF THE OTHER?
   if (!is.call(user) || !is.call(solution)) {
     if (!identical(user, solution)) {
+      if (detect_mismatched_function_arguments(user, solution)) {
+        submitted <- as.pairlist(user[setdiff(names(user), names(solution))])
+        solution <- as.pairlist(solution[setdiff(names(solution), names(user))])
+      }
+      
       return(
         wrong_value(
           this = submitted,
@@ -422,4 +427,10 @@ detect_mistakes <- function(user,
 real_names <- function(x) {
   x_names <- rlang::names2(x)
   x_names[x_names != ""]
+}
+
+detect_mismatched_function_arguments <- function(user, solution) {
+  is.pairlist(user) && 
+    is.pairlist(solution) &&
+    length(user) != length(solution)
 }

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -227,7 +227,7 @@ debug_this <- function(check_env = parent.frame()) {
   
   prnt <- function(x) {
     if (inherits(x, "AsIs")) return(x)
-    capture.output(print(x))
+    utils::capture.output(print(x))
   }
   
   solution_code <- get_check_env(".solution_code")

--- a/R/message_generators.R
+++ b/R/message_generators.R
@@ -335,8 +335,8 @@ wrong_value <- function(this,
   # "{intro}I expected {that} where you wrote {this}."
 
   intro <- build_intro(.call = enclosing_call)
-  expected <- "expected"
 
+  expected <- "expected"
   if (length(this) > length(that)) {
     expected <- "didn't expect"
     that <- this
@@ -347,13 +347,13 @@ wrong_value <- function(this,
   
   that_original <- that
   that <- prep(that)
-  this <- 
-    if (is.null(this)) {
-      intro <- ""
-      build_intro(enclosing_call %||% that_original, .open = "", .close = "")
-    } else {
-      prep(this)
-    }
+   
+  if (is.null(this)) {
+    intro <- ""
+    this <- build_intro(enclosing_call %||% that_original, .open = "", .close = "")
+  } else {
+    this <-prep(this)
+  }
       
   if (!is.null(this_name) && this_name != "") {
     that <- md_code_prepend(paste(this_name, "= "), that)

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,12 @@ is_pipe <- function(x) {
 }
 
 .infixes_assign <- c("<-", "<<-", "->", "->>", "=")
-.infixes <- c("+", "-", "*", "/", "^", "%%", "%/%", "%in%", .infixes_assign)
+.infixes_comp <- c("==", "!=", ">", ">=", "<", "<=")
+.infixes <- c(
+  "+", "-", "*", "/", "^", "$", "[", "[[", "!", "%%", "%/%", "%in%", 
+  .infixes_assign,
+  .infixes_comp
+)
 
 is_infix <- function(x, infix_vals = .infixes) {
 

--- a/tests/testthat/test_detect_mistakes.R
+++ b/tests/testthat/test_detect_mistakes.R
@@ -871,14 +871,14 @@ test_that("detect_mistakes : Differentiate between 'strings' and objects in mess
 test_that("detect_mistakes works with function arguments", {
   expect_equal(
     detect_mistakes(as.pairlist(alist(x = , y = )), as.pairlist(alist(x = , y = , z =))),
-    "I expected arguments `x`, `y`, `z` where you wrote arguments `x`, `y`." 
+    "I expected argument `z`." 
   )
   
   expect_grade_code(
     user_code = "function(x, y, z) x + y",
     solution_code = "function(x, y) x + y",
     is_correct = FALSE,
-    msg = "In `function(x, y, z)`, I expected arguments `x`, `y` where you wrote arguments `x`, `y`, `z`."
+    msg = "I didn't expect argument `z` where you wrote `function(x, y, z)`."
   )
   
   expect_grade_code(
@@ -928,4 +928,27 @@ test_that("detect_mistakes returns a reasonable amount of intro context", {
   expect_false(grepl("^In ", feedback))
   expect_match(feedback, "scale_color_brewer", fixed = TRUE)
   expect_match(feedback, "scale_fill_brewer", fixed = TRUE)
+})
+
+test_that("detect_mistakes says 'didn't expect' when there are too many things", {
+  expect_grade_code(
+    user_code = "a$b",
+    solution_code = "a",
+    is_correct = FALSE,
+    msg = "I didn't expect `$` where you wrote `a$b`."
+  )
+  
+  expect_grade_code(
+    user_code = "a == b",
+    solution_code = "a",
+    is_correct = FALSE,
+    msg = "I didn't expect `==` where you wrote `a == b`."
+  )
+  
+  expect_grade_code(
+    user_code = "a * b",
+    solution_code = "a",
+    is_correct = FALSE,
+    msg = "I didn't expect `*` where you wrote `a * b`."
+  )
 })

--- a/tests/testthat/test_detect_mistakes.R
+++ b/tests/testthat/test_detect_mistakes.R
@@ -593,6 +593,47 @@ test_that("detect_mistakes works with pipes", {
 
 })
 
+test_that("detect_mistakes handles a mix of named and unnamed arguments and with pipes", {
+  env = new.env()
+  env$fn <- function(.data, ...) .data
+  
+  expect_equal(
+    detect_mistakes(
+      quote(x %>% fn(name == "John")),
+      quote(x %>% fn(name == "Paul")),
+      env = env
+    ),
+    wrong_value("John", "Paul", enclosing_call = quote(name == "John"))
+  )
+  
+  expect_equal(
+    detect_mistakes(
+      quote(fn(x, name == "John")),
+      quote(fn(.data = x, name == "Paul")),
+      env = env
+    ),
+    wrong_value("John", "Paul", enclosing_call = quote(name == "John"))
+  )
+
+  expect_equal(
+    detect_mistakes(
+      quote(fn(x = 1, 2)),
+      quote(fn(x = 1)),
+      env = env
+    ),
+    surplus_argument(quote(fn()), quote(2), "")
+  )
+  
+  expect_equal(
+    detect_mistakes(
+      quote(fn(x = 1, 2)),
+      quote(fn(x = 1)),
+      env = env
+    ),
+    surplus_argument(quote(fn()), quote(2), "")
+  )
+})
+
 test_that("detect_mistakes handles argument names correctly", {
   user <-     quote(c(x = a(b(1))))
   solution <- quote(c(x = b(1)))

--- a/tests/testthat/test_detect_mistakes.R
+++ b/tests/testthat/test_detect_mistakes.R
@@ -869,9 +869,12 @@ test_that("detect_mistakes : Differentiate between 'strings' and objects in mess
 
 
 test_that("detect_mistakes works with function arguments", {
-  expect_equal(
-    detect_mistakes(as.pairlist(alist(x = , y = )), as.pairlist(alist(x = , y = , z =))),
-    "I expected argument `z`." 
+  expect_match(
+    detect_mistakes(
+      as.pairlist(alist(x = , y = )), 
+      as.pairlist(alist(x = , y = , z =))
+    ),
+    "I expected argument `z`" 
   )
   
   expect_grade_code(


### PR DESCRIPTION
Fixes #215

## Before

```r
grade_code()(mock_this_exercise(
  'band_members %>% filter(name == "Mick")',
  'band_members %>% filter(name == "John")',
  setup_exercise = "library(dplyr)"
))
#> <gradethis_graded: [Incorrect] I see that you are using pipe operators (e.g. %>%),
#> so I want to let you know that this is how I am interpretting your code before I
#> check it:
#> 
#> ```r
#> filter(band_members, name == "Mick")
#> ```
#> 
#> In `band_members %>% filter(name == "Mick")`, I expected you to ``==`()` where you
#> wrote `band_members`.  Let's try it again.>

grade_this_code()(
  list(
    .user_code = "ggplot(data = mpg, mapping = aes(x = displ, y = hwy, alpha = class, 0.1)) + geom_point()", 
    .solution_code = "ggplot(data = mpg, mapping = aes(x = displ, y = hwy, alpha = class)) + geom_point()"
  )
)
#> <gradethis_graded_this_code: [Incorrect] I did not expect your call to `aes()`
#> to include `x = displ`. You may have included an unnecessary argument, or you
#> may have left out or misspelled an important argument name. Let's try it again.>

demo <- function(x = 1, ...) {
  list(x, ...)
}

gradethis::grade_this_code()(
  list(
    .user_code = "demo(x = 1, 2)", 
    .solution_code = "demo(x = 1)"
  )
)
#> <gradethis_graded_this_code: [Incorrect] I did not expect your call to `demo()`
#> to include `x = 1`. You may have included an unnecessary argument, or you may
#> have left out or misspelled an important argument name. Try it again. You get
#> better each time.>
```

## After

```r
grade_code()(mock_this_exercise(
  'band_members %>% filter(name == "Mick")',
  'band_members %>% filter(name == "John")',
  setup_exercise = "library(dplyr)"
))
#> <gradethis_graded: [Incorrect] I see that you are using pipe operators (e.g. %>%),
#> so I want to let you know that this is how I am interpretting your code before I
#> check it:
#> 
#> ```r
#> filter(band_members, name == "Mick")
#> ```
#> 
#> In `name == "Mick"`, I expected `"John"` where you wrote `"Mick"`.  Try it again;
#> next time's the charm!>

grade_this_code()(
  list(
    .user_code = "ggplot(data = mpg, mapping = aes(x = displ, y = hwy, alpha = class, 0.1)) + geom_point()", 
    .solution_code = "ggplot(data = mpg, mapping = aes(x = displ, y = hwy, alpha = class)) + geom_point()"
  )
)
#> <gradethis_graded_this_code: [Incorrect] I did not expect your call to `aes()` to
#> include `0.1`. You may have included an unnecessary argument, or you may have left
#> out or misspelled an important argument name. Let's try it again.>

demo <- function(x = 1, ...) {
  list(x, ...)
}

gradethis::grade_this_code()(
  list(
    .user_code = "demo(x = 1, 2)", 
    .solution_code = "demo(x = 1)"
  )
)
#> <gradethis_graded_this_code: [Incorrect] I did not expect your call to `demo()`
#> to include `2`. You may have included an unnecessary argument, or you may have
#> left out or misspelled an important argument name. That's okay: you learn more
#> from mistakes than successes. Let's do it one more time.>
```