### PR TITLE
Use global env not base env in mock_this_exercise()

### DIFF
--- a/R/mock.R
+++ b/R/mock.R
@@ -84,7 +84,7 @@ mock_this_exercise <- function(
   .engine <- tolower(.engine)
   .engine <- match.arg(.engine)
   
-  env_global <- rlang::env(baseenv())
+  env_global <- rlang::env(globalenv())
   
   .user_code <- rlang::enexpr(.user_code)
   .solution_code <- rlang::enexpr(.solution_code)


### PR DESCRIPTION
Using `baseenv()` was too restrictive for some tests/mocking scenarios
