### PR TITLE
user, solution and check code should always be a string

### DIFF
--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -69,7 +69,7 @@ check_exercise <- function(
   last_value = NULL,
   ...
 ) {
-
+  
   learnr_args <- list(
     label = label,
     solution_code = solution_code,
@@ -82,7 +82,7 @@ check_exercise <- function(
     ...
   )
   
-  if (!(length(user_code) && nzchar(trimws(user_code)))) {
+  if (length(user_code) == 0 || !any(nzchar(trimws(user_code)))) {
     return(feedback(
       fail("I didn't receive your code. Did you write any?"),
       type = "info"
@@ -104,13 +104,15 @@ check_exercise <- function(
 
   # Copy over all learnr args into the checking environment
   for (name in names(learnr_args)) {
+    learnr_arg <- learnr_args[[name]]
+    name <- paste0(".", name)
+    
     # Ensure that code objects are always a length-1 character string
-    transform <- identity
-    if (grepl("code", name) && is.character(learnr_args[[name]])) {
-      transform <- function(x) paste(x, collapse = "\n")
+    if (length(learnr_arg) > 1 && grepl("code", name) && is.character(learnr_arg)) {
+      learnr_arg <- paste(learnr_arg, collapse = "\n")
     }
     
-    check_obj_envir[[paste0(".", name)]] <- transform(learnr_args[[name]])
+    check_obj_envir[[name]] <- learnr_arg
   }
 
   # Add gradethis specific check objects

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -96,7 +96,7 @@ check_exercise <- function(
       paste0(label, "-check")
     }
 
-  ## setup environemtns for checking
+  ## setup environments for checking
   # envir for function call
   chunk_envir <- learnr::duplicate_env(envir_prep)
   # envir where checking is called (checking returns from here)

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -104,7 +104,13 @@ check_exercise <- function(
 
   # Copy over all learnr args into the checking environment
   for (name in names(learnr_args)) {
-    check_obj_envir[[paste0(".", name)]] <- learnr_args[[name]]
+    # Ensure that code objects are always a length-1 character string
+    transform <- identity
+    if (grepl("code", name) && is.character(learnr_args[[name]])) {
+      transform <- function(x) paste(x, collapse = "\n")
+    }
+    
+    check_obj_envir[[paste0(".", name)]] <- transform(learnr_args[[name]])
   }
 
   # Add gradethis specific check objects

--- a/tests/testthat/test_grade_this_learnr.R
+++ b/tests/testthat/test_grade_this_learnr.R
@@ -55,6 +55,38 @@ test_that("length 0 user code", {
   )
 })
 
+test_that("user and solution code are always length 1", {
+  expect_exercise_checker(
+    is_correct = TRUE,
+    msg = "TEST PASSED",
+    user_code = c("1", "2", "3"),
+    check_code = "grade_this(if (length(.user_code) == 1) pass('TEST PASSED') else fail('TEST FAILED'))"
+  )
+  
+  expect_exercise_checker(
+    is_correct = TRUE,
+    msg = "TEST PASSED",
+    user_code = c("1", "2", "3"),
+    solution_code= c("1", "2", "3", "4"),
+    check_code = "grade_this(if (length(.solution_code) == 1) pass('TEST PASSED') else fail('TEST FAILED'))"
+  )
+  
+  expect_exercise_checker(
+    is_correct = TRUE,
+    msg = "TEST PASSED",
+    user_code = c("1", "2", "3"),
+    solution_code= c("1", "2", "3", "4"),
+    check_code = c(
+      "grade_this(", 
+      "if (length(.check_code) == 1)",
+      "pass('TEST PASSED')", 
+      "else", 
+      "fail('TEST FAILED')", 
+      ")"
+    )
+  )
+})
+
 # "A problem occurred with your teacher's grading code. Defaulting to _incorrect_."
 message_feedback_grading_problem <- feedback_grading_problem()$message
 


### PR DESCRIPTION
`user_code` and `check_code` are almost always a single string but `solution_code` is sometimes a vector (because its pulled from `knitr::knit_code$get()`).

This PR ensures that, at the gradethis level, these objects are _always_ a length-1 string.