### PR TITLE
Refactor prepare_check_obj_envir() into prepare_check_env()

### DIFF
--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -195,7 +195,7 @@ prepare_check_env <- function(learnr_args, envir_caller = rlang::caller_env()) {
   # evaluating all of exercise setup code, duplicated to avoid the possibility
   # of the checking code changing the prep environment
   envir_base <- learnr::duplicate_env(learnr_args[["envir_prep"]])
-  check_obj_envir <- new.env(parent = envir_base)
+  check_env <- new.env(parent = envir_base)
   
   force(envir_caller)
   
@@ -209,17 +209,17 @@ prepare_check_env <- function(learnr_args, envir_caller = rlang::caller_env()) {
       learnr_arg <- paste(learnr_arg, collapse = "\n")
     }
     
-    check_obj_envir[[name]] <- learnr_arg
+    check_env[[name]] <- learnr_arg
   }
   
   # Add gradethis specific check objects
-  check_obj_envir[[".result"]] <- learnr_args[["last_value"]]
-  check_obj_envir[[".user"]] <- learnr_args[["last_value"]]
+  check_env[[".result"]] <- learnr_args[["last_value"]]
+  check_env[[".user"]] <- learnr_args[["last_value"]]
   
   # Delayed evaluation of `.solution`
   solution_expr <- parse(text = learnr_args[["solution_code"]] %||% "")
   delayedAssign(
-    assign.env = check_obj_envir,
+    assign.env = check_env,
     x = ".solution",
     {
       if (length(solution_expr) == 0) {
@@ -237,7 +237,7 @@ prepare_check_env <- function(learnr_args, envir_caller = rlang::caller_env()) {
       }
     }
   )
-  check_obj_envir
+  check_env
 }
 
 grade_parse_error <- function(check_obj) {

--- a/R/gradethis_exercise_checker.R
+++ b/R/gradethis_exercise_checker.R
@@ -191,10 +191,13 @@ check_exercise <- function(
 
 
 prepare_check_env <- function(learnr_args, envir_caller = rlang::caller_env()) {
+  # The check_env starts from a copy of envir_prep which is the result of
+  # evaluating all of exercise setup code, duplicated to avoid the possibility
+  # of the checking code changing the prep environment
   envir_base <- learnr::duplicate_env(learnr_args[["envir_prep"]])
-  force(envir_caller)
-  
   check_obj_envir <- new.env(parent = envir_base)
+  
+  force(envir_caller)
   
   # Copy over all learnr args into the checking environment
   for (name in names(learnr_args)) {


### PR DESCRIPTION
This PR cleans up the previous refactor of `prepare_check_obj_envir()`. I've renamed the function `prepare_check_env()` since `check_env` is the name used for that object elsewhere.

I also refactored the function so that it now takes only `learnr_args` as a list and creates a `check_env` from that list. I think this will make it easier to isolate our logic or for other packages that might extend gradethis to understand how the `check_env` is produced from the learnr inputs.